### PR TITLE
✨ Better error message when attempting to save a file while not being connected to an instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ test-search2
 test-search3
 test-search4
 test-search5
+test.ipynb
+
 # General
 .DS_Store
 

--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -4,6 +4,7 @@ from typing import Union
 import lamindb_setup as ln_setup
 from lamin_utils import logger
 import re
+from click import ClickException
 
 
 def parse_uid_from_code(
@@ -52,6 +53,9 @@ def parse_uid_from_code(
 
     return uid, stem_uid, version
 
+class ClickInstanceNotSetupError(ClickException):
+        def show(self, file=None):
+            pass
 
 def save_from_filepath_cli(
     filepath: Union[str, Path],
@@ -71,6 +75,9 @@ def save_from_filepath_cli(
     from lamindb._finish import save_context_core
 
     ln_setup.settings.auto_connect = auto_connect_state
+    
+    if not ln_setup._check_instance_setup():
+        raise ClickInstanceNotSetupError("Save requires to be connected to an instance.")
 
     if registry is None:
         registry = "transform" if filepath.suffix in {".py", ".ipynb"} else "artifact"

--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -40,9 +40,11 @@ def parse_uid_from_code(content: str, suffix: str) -> str | None:
 
     return uid
 
+
 class ClickInstanceNotSetupError(ClickException):
-        def show(self, file=None):
-            pass
+    def show(self, file=None):
+        pass
+
 
 def save_from_filepath_cli(
     filepath: Union[str, Path],
@@ -59,16 +61,17 @@ def save_from_filepath_cli(
     # instances sequentially
     auto_connect_state = ln_setup.settings.auto_connect
     ln_setup.settings.auto_connect = True
-    
+
     if not ln_setup._check_instance_setup():
         from lamindb_setup._check_setup import InstanceNotSetupError
+
         raise ClickInstanceNotSetupError(InstanceNotSetupError.default_message)
 
     import lamindb as ln
     from lamindb._finish import save_context_core
 
     ln_setup.settings.auto_connect = auto_connect_state
-    
+
     suffixes_transform = {
         "py": set([".py", ".ipynb"]),
         "R": set([".R", ".qmd", ".Rmd"]),

--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -59,15 +59,16 @@ def save_from_filepath_cli(
     # instances sequentially
     auto_connect_state = ln_setup.settings.auto_connect
     ln_setup.settings.auto_connect = True
+    
+    if not ln_setup._check_instance_setup():
+        from lamindb_setup._check_setup import InstanceNotSetupError
+        raise ClickInstanceNotSetupError(InstanceNotSetupError.default_message)
 
     import lamindb as ln
     from lamindb._finish import save_context_core
 
     ln_setup.settings.auto_connect = auto_connect_state
     
-    if not ln_setup._check_instance_setup():
-        raise ClickInstanceNotSetupError("Save requires to be connected to an instance.")
-
     suffixes_transform = {
         "py": set([".py", ".ipynb"]),
         "R": set([".R", ".qmd", ".Rmd"]),


### PR DESCRIPTION
Solves the initial report of @chaichontat in https://github.com/laminlabs/lamindb/issues/1585

We are now raising an exception when attempting to save a file but are not connected to an instance. We already cover cases where one attempts to save something but is not connected to an instance in the general API so I think it's fine if I ammend only the CLI version here.

Before:
```
⋊> ~/P/lamin-cli on feature/save_django_msg  lamin save test.ipynb                                                                                                        
! To use lamindb, you need to connect to an instance.

Connect to an instance: `ln.connect()`. Init an instance: `ln.setup.init()`.

If you used the CLI to set up lamindb in a notebook, restart the Python session.

Traceback (most recent call last):
  File "/home/zeth/miniconda3/envs/lamindb/bin/lamin", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/rich_click/rich_command.py", line 367, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/rich_click/rich_command.py", line 152, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/PycharmProjects/lamin-cli/lamin_cli/__main__.py", line 285, in save
    if save_from_filepath_cli(filepath, key, description, registry) is not None:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/PycharmProjects/lamin-cli/lamin_cli/_save.py", line 65, in save_from_filepath_cli
    from lamindb._finish import save_context_core
  File "/home/zeth/PycharmProjects/lamindb/lamindb/_finish.py", line 11, in <module>
    from lamindb.core.exceptions import NotebookNotSaved
  File "/home/zeth/PycharmProjects/lamindb/lamindb/core/__init__.py", line 72, in <module>
    from lamindb._query_manager import QueryManager
  File "/home/zeth/PycharmProjects/lamindb/lamindb/_query_manager.py", line 9, in <module>
    from lamindb.models import Record
  File "/home/zeth/PycharmProjects/lamindb/lamindb/models.py", line 75, in <module>
    class IsVersioned(models.Model):
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/db/models/base.py", line 129, in __new__
    app_config = apps.get_containing_app_config(module)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/apps/registry.py", line 260, in get_containing_app_config
    self.check_apps_ready()
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/apps/registry.py", line 137, in check_apps_ready
    settings.INSTALLED_APPS
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/conf/__init__.py", line 81, in __getattr__
    self._setup(name)
  File "/home/zeth/miniconda3/envs/lamindb/lib/python3.11/site-packages/django/conf/__init__.py", line 61, in _setup
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```

After:
```
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ To use lamindb, you need to connect to an instance.                                                                                                                                       │
│                                                                                                                                                                                           │
│ Connect to an instance: `ln.connect()`. Init an instance: `ln.setup.init()`.                                                                                                              │
│                                                                                                                                                                                           │
│ If you used the CLI to set up lamindb in a notebook, restart the Python session.                                                                                                          │
│                                                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```