### PR TITLE
🚸 Resolve save FutureWarning

### DIFF
--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -123,7 +123,7 @@ def save_from_filepath_cli(
             transform = ln.Transform.filter(key=filepath.name).one_or_none()
             if transform is None:
                 transform = ln.Transform(
-                    name=filepath.name,
+                    description=filepath.name,
                     key=filepath.name,
                     type="script" if filepath.suffix in {".R", ".py"} else "notebook",
                 ).save()


### PR DESCRIPTION
This is not nice.

```
lukas@lukas ~/c/hubmap_registration> lamin save query.py                                                                            (lamindb) 
→ connected lamindb: laminlabs/hubmap
/home/lukas/miniforge3/envs/lamindb/lib/python3.12/site-packages/lamin_cli/_save.py:125: FutureWarning: `name` will be removed soon, please pass 'query.py' to `description` instead
```

