### PR TITLE
✨ Provide a tracked REPL for the lamin cli

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -222,6 +222,18 @@ def info(schema: bool):
         click.echo(settings_)
 
 
+@main.command()
+@click.argument("instance", type=str, default=None)
+def repl(instance: str):
+    """Run a tracked interactive python shell."""
+    from lamindb_setup import settings as settings_
+
+    from lamin_cli._repl import LaminConsole
+
+    settings_.auto_connect = False
+    LaminConsole().tracked_interact(instance)
+
+
 # fmt: off
 @main.command()
 @click.argument("instance", type=str, default=None)

--- a/lamin_cli/_repl.py
+++ b/lamin_cli/_repl.py
@@ -1,0 +1,84 @@
+import importlib
+import sys
+import uuid
+from code import InteractiveConsole
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+
+class LaminConsole(InteractiveConsole):
+    """A minimally wrapped interactive console for tracking."""
+
+    locals: dict[str, Any]
+
+    def __init__(self):
+        _locals = {}
+        super().__init__(locals=_locals, filename="<console>")
+        self.history = []
+
+    def resetbuffer(self):
+        """Reset the input buffer."""
+        if getattr(self, "buffer", []):
+            self.history.append("\n".join(self.buffer))
+        self.buffer = []
+
+    def tracked_interact(self, instance: str | None):
+        key = f"interactive-{uuid.uuid4()}"
+        self.filename = f"{key}.py"
+
+        banner = [
+            f"Lamin CLI Python {sys.version} on {sys.platform}",
+            "This session is tracked on your lamin instance.",
+            "",
+        ]
+        self.write("\n".join(banner))
+
+        self.write(">>> import lamindb as ln\n")
+        self.history.append("import lamindb as ln")
+        ln = importlib.import_module("lamindb")
+
+        if instance is not None:
+            self.write(f'>>> ln.connect("{instance}")\n')
+            self.history.append(f'ln.connect("{instance}")')
+            ln.connect(instance)
+
+        # make sure to error early in case connect didn't connect
+        ln_finish = importlib.import_module("lamindb._finish")
+
+        with TemporaryDirectory(prefix="lamin-cli-") as tdir:
+            source = Path(tdir).joinpath(self.filename)
+
+            self.write(">>> ln.track()\n")
+            # FIXME: type should be "interactive"
+            t = ln.Transform(key=key, type="script").save()
+            ln.track(t.uid, path=source)
+            self.history.append(f'ln.track("{t.uid}")')
+
+            self.locals.update(
+                {
+                    "__main__": t.key,
+                    "__doc__": None,
+                    "ln": ln,
+                }
+            )
+
+            try:
+                self.interact(banner=False)  # type: ignore
+            finally:
+                source.write_text("\n".join(self.history))
+
+                ln_finish.save_context_core(
+                    run=ln.context.run,
+                    transform=t,
+                    filepath=source,
+                    finished_at=True,
+                    ignore_non_consecutive=None,
+                    from_cli=True,
+                    is_retry=False,
+                )
+
+
+if __name__ == "__main__":
+    console = LaminConsole()
+    console.tracked_interact(sys.argv[1])


### PR DESCRIPTION
Hey Lamins,

I sometimes find myself making a quick change in the python interpreter and I'd like to keep track of this somehow.
To check how complicated an implementation could be, I made a quick proof of concept for tracking interactive shell usage.

Ideally this would probably build on ipython to be a bit more feature rich, but I think this can be implemented in an afternoon.

This **proof-of-concept PR** adds `lamin repl` as a cli command:

```console
❯ lamin repl user/instance
Lamin CLI Python 3.12.8 (main, Dec  3 2024, 18:42:41) [Clang 16.0.0 (clang-1600.0.26.4)] on darwin
This session is tracked on your lamin instance.
>>> import lamindb as ln
>>> ln.connect("user/instance")
>>> ln.track()
→ updated transform description, loaded Transform('GqB9xtcBHmqv0000'), started new Run('02uXPwNj...') at 2025-02-21 12:21:58 UTC
>>> import pandas as pd
>>> ln.Artifact.from_df(pd.DataFrame({"A":[1,2,3]}), description="repl").save()
... uploading hu6ApyOvSuw12YWg0000.parquet: 100.0%
Artifact(uid='hu6ApyOvSuw12YWg0000', is_latest=True, description='repl', suffix='.parquet', kind='dataset', otype='DataFrame', size=1571, hash='ZaO9nevOHyNYuWxs9jjerg', space_id=1, storage_id=2, run_id=42, created_by_id=4, created_at=2025-02-21 12:22:55 UTC)
>>> exit()
→ go to: https://lamin.ai/user/instance/transform/GqB9xtcBHmqv0000

```

Which let's you store the interactive shell commands in the instance

```console
❯ lamin load https://lamin.ai/user/instance/transform/GqB9xtcBHmqv0000
→ script is here: interactive-7eaaf87d-0fd2-4087-8b4e-a4a0dc0dd106

❯ cat interactive-7eaaf87d-0fd2-4087-8b4e-a4a0dc0dd106 
import lamindb as ln
ln.connect("user/instance")
ln.track("GqB9xtcBHmqv0000")
import pandas as pd
ln.Artifact.from_df(pd.DataFrame({"A":[1,2,3]}), description="repl").save()

```   

Cheers,
Andreas
