### PR TITLE
✨ Allow `lamin save` with cloud paths

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -329,6 +329,8 @@ def save(path: str, key: str, description: str, stem_uid: str, project: str, reg
     an {class}`~lamindb.Artifact` by passing `--registry artifact`.
     """
     objpath = UPath(path)
+    if not objpath.exists():
+        raise click.BadParameter(f"Path {path} does not exist", param_hint="path")
 
     from lamin_cli._save import save_from_path_cli
 

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -8,6 +8,7 @@ import warnings
 from collections import OrderedDict
 from functools import wraps
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lamindb_setup._init_instance import (
@@ -16,7 +17,6 @@ from lamindb_setup._init_instance import (
     DOC_MODULES,
     DOC_STORAGE_ARG,
 )
-from upath import UPath
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -328,13 +328,9 @@ def save(path: str, key: str, description: str, stem_uid: str, project: str, reg
     other file types and folders as {class}`~lamindb.Artifact`. You can enforce saving a file as
     an {class}`~lamindb.Artifact` by passing `--registry artifact`.
     """
-    upath = UPath(path)
-    if not upath.exists():
-        raise click.BadParameter(f"Path {path} does not exist", param_hint="path")
-
     from lamin_cli._save import save_from_path_cli
 
-    if save_from_path_cli(upath, key, description, stem_uid, project, registry) is not None:
+    if save_from_path_cli(path, key, description, stem_uid, project, registry) is not None:
         sys.exit(1)
 
 
@@ -358,13 +354,13 @@ def run(filepath: str, project: str, image_url: str, packages: str, cpu: int, gp
     """
     from lamin_cli.compute.modal import Runner
 
-    default_mount_dir = UPath('./modal_mount_dir')
+    default_mount_dir = Path('./modal_mount_dir')
     if not default_mount_dir.is_dir():
         default_mount_dir.mkdir(parents=True, exist_ok=True)
 
     shutil.copy(filepath, default_mount_dir)
 
-    filepath_in_mount_dir = default_mount_dir / UPath(filepath).name
+    filepath_in_mount_dir = default_mount_dir / Path(filepath).name
 
     package_list = []
     if packages:

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -328,13 +328,13 @@ def save(path: str, key: str, description: str, stem_uid: str, project: str, reg
     other file types and folders as {class}`~lamindb.Artifact`. You can enforce saving a file as
     an {class}`~lamindb.Artifact` by passing `--registry artifact`.
     """
-    objpath = UPath(path)
-    if not objpath.exists():
+    upath = UPath(path)
+    if not upath.exists():
         raise click.BadParameter(f"Path {path} does not exist", param_hint="path")
 
     from lamin_cli._save import save_from_path_cli
 
-    if save_from_path_cli(path, key, description, stem_uid, project, registry) is not None:
+    if save_from_path_cli(upath, key, description, stem_uid, project, registry) is not None:
         sys.exit(1)
 
 

--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -119,26 +119,26 @@ def save_from_path_cli(
 
     if registry == "transform":
         if objpath.suffix in {".qmd", ".Rmd"}:
-            if not (
-                objpath.with_suffix(".html").exists()
-                or objpath.with_suffix(".nb.html").exists()
-            ):
-                raise SystemExit(
+            html_file_exists = objpath.with_suffix(".html").exists()
+            nb_html_file_exists = objpath.with_suffix(".nb.html").exists()
+
+            if not html_file_exists and not nb_html_file_exists:
+                logger.error(
                     f"Please export your {objpath.suffix} file as an html file here"
                     f" {objpath.with_suffix('.html')}"
                 )
-            if (
-                objpath.with_suffix(".html").exists()
-                and objpath.with_suffix(".nb.html").exists()
-            ):
-                raise SystemExit(
+                return "export-qmd-Rmd-as-html"
+            elif html_file_exists and nb_html_file_exists:
+                logger.error(
                     f"Please delete one of\n - {objpath.with_suffix('.html')}\n -"
                     f" {objpath.with_suffix('.nb.html')}"
                 )
+                return "delete-html-or-nb-html"
 
         with objpath.open() as file:
             content = file.read()
         uid = parse_uid_from_code(content, objpath.suffix)
+
         if uid is not None:
             logger.important(f"mapped '{objpath}' on uid '{uid}'")
             transform = ln.Transform.filter(uid=uid).one_or_none()

--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -105,7 +105,7 @@ def save_from_path_cli(
 
         if is_cloud_path:
             if key is not None:
-                logger.error("Do not pass a key for cloud paths")
+                logger.error("Do not pass --key for cloud paths")
                 return "key-with-cloud-path"
         elif key is None and description is None:
             logger.error("Please pass a key or description via --key or --description")

--- a/tests/core/test_save_files.py
+++ b/tests/core/test_save_files.py
@@ -7,7 +7,7 @@ import lamindb_setup as ln_setup
 test_file = Path(__file__).parent.parent.parent.resolve() / ".gitignore"
 
 
-def test_save_file():
+def test_save_local_file():
     filepath = test_file
 
     # neither key nor description
@@ -64,3 +64,19 @@ def test_save_file():
         in result.stderr.decode()
     )
     assert result.returncode == 1
+
+
+def test_save_cloud_file():
+    # should be no key for cloud paths
+    result = subprocess.run(
+        "lamin save s3://lamindb-ci/lndb-storage/testfile.hdf5 --key filekey.h5ad",
+        shell=True,
+        check=False,
+    )
+    assert result.returncode == 1
+
+    result = subprocess.run(
+        "lamin save s3://lamindb-ci/lndb-storage/testfile.hdf5",
+        shell=True,
+        check=True,
+    )

--- a/tests/core/test_save_r_code.py
+++ b/tests/core/test_save_r_code.py
@@ -55,7 +55,7 @@ def test_run_save_cache():
     # print(result.stdout.decode())
     # print(result.stderr.decode())
     assert result.returncode == 1
-    assert "Please export your" in result.stderr.decode()
+    assert "Please export your" in result.stdout.decode()
 
     filepath.with_suffix(".html").write_text("dummy html")
 


### PR DESCRIPTION
Close https://github.com/laminlabs/lamindb/issues/2693

Allows to pass cloud paths to `lamin save` to create artifacts.

Example:

```
lamin save s3://lamindb-ci/lndb-storage/testfile.hdf5
```