### PR TITLE
🚸 Allow omitting `entity` in `lamin load`

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -322,35 +322,39 @@ def delete(entity: str, name: str | None = None, uid: str | None = None, slug: s
 
 
 @main.command()
-@click.argument("entity", type=str)
+@click.argument("entity", type=str, required=False)
 @click.option("--uid", help="The uid for the entity.")
 @click.option("--key", help="The key for the entity.")
 @click.option(
     "--with-env", is_flag=True, help="Also return the environment for a tranform."
 )
-def load(entity: str, uid: str | None = None, key: str | None = None, with_env: bool = False):
+def load(entity: str | None = None, uid: str | None = None, key: str | None = None, with_env: bool = False):
     """Load a file or folder into the cache or working directory.
 
-    Pass a URL, `artifact`, or `transform`. For example:
+    Pass a URL or `--key`. For example:
 
     ```
     lamin load https://lamin.ai/account/instance/artifact/e2G7k9EVul4JbfsE
-    lamin load artifact --key mydatasets/mytable.parquet
+    lamin load --key mydatasets/mytable.parquet
+    lamin load --key analysis.ipynb
+    lamin load --key myanalyses/analysis.ipynb --with-env
+    ```
+
+    You can also pass a uid and the entity type:
+
+    ```
     lamin load artifact --uid e2G7k9EVul4JbfsE
-    lamin load transform --key analysis.ipynb
     lamin load transform --uid Vul4JbfsEYAy5
-    lamin load transform --uid Vul4JbfsEYAy5 --with-env
     ```
     """
-    is_slug = entity.count("/") == 1
-    if is_slug:
-        from lamindb_setup._connect_instance import _connect_cli
-        # for backward compat and convenience, connect to the instance
-        return _connect_cli(entity)
-    else:
-        from lamin_cli._load import load as load_
-
-        return load_(entity, uid=uid, key=key, with_env=with_env)
+    from lamin_cli._load import load as load_
+    if entity is not None:
+        is_slug = entity.count("/") == 1
+        if is_slug:
+            from lamindb_setup._connect_instance import _connect_cli
+            # for backward compat
+            return _connect_cli(entity)
+    return load_(entity, uid=uid, key=key, with_env=with_env)
 
 
 def _describe(entity: str = "artifact", uid: str | None = None, key: str | None = None):

--- a/lamin_cli/_load.py
+++ b/lamin_cli/_load.py
@@ -6,12 +6,15 @@ from pathlib import Path
 
 from lamin_utils import logger
 
-from ._save import parse_title_r_notebook
+from ._save import infer_registry_from_path, parse_title_r_notebook
 from .urls import decompose_url
 
 
 def load(
-    entity: str, uid: str | None = None, key: str | None = None, with_env: bool = False
+    entity: str | None = None,
+    uid: str | None = None,
+    key: str | None = None,
+    with_env: bool = False,
 ):
     """Load artifact, collection, or transform from LaminDB.
 
@@ -25,6 +28,12 @@ def load(
         Path to loaded transform, or None for artifacts/collections
     """
     import lamindb_setup as ln_setup
+
+    if entity is None:
+        if key is None:
+            raise SystemExit("Either entity or key has to be provided.")
+        else:
+            entity = infer_registry_from_path(key)
 
     if entity.startswith("https://") and "lamin" in entity:
         url = entity

--- a/tests/core/test_load.py
+++ b/tests/core/test_load.py
@@ -18,10 +18,6 @@ def test_decompose_url():
 
 
 def test_load_transform():
-    import lamindb_setup as ln_setup
-
-    print(ln_setup.settings.instance.slug)
-
     # check via a renamed instance
     result = subprocess.run(
         "lamin load"
@@ -39,11 +35,7 @@ def test_load_transform():
         shell=True,
         capture_output=True,
     )
-    print(result.stdout.decode())
-    print(result.stderr.decode())
     assert result.returncode == 0
-
-    print(ln_setup.settings.instance.slug)
 
     path1 = Path("run-track-and-finish.py")
     path2 = Path("run-track-and-finish__requirements.txt")
@@ -74,6 +66,7 @@ def test_load_transform():
 
 
 def test_get_load_artifact():
+    # test get
     result = subprocess.run(
         "lamin get"
         " 'https://lamin.ai/laminlabs/lamin-site-assets/artifact/e2G7k9EVul4JbfsEYAy5'",
@@ -82,6 +75,7 @@ def test_get_load_artifact():
     )
     assert result.returncode == 0
 
+    # test load
     result = subprocess.run(
         "lamin load"
         " 'https://lamin.ai/laminlabs/lamin-site-assets/artifact/e2G7k9EVul4JbfsEYAy5'",
@@ -90,11 +84,20 @@ def test_get_load_artifact():
     )
     assert result.returncode == 0
 
+    # connect to instance
     subprocess.run("lamin connect laminlabs/lamin-site-assets", shell=True)
 
     # partial uid
     result = subprocess.run(
         "lamin load artifact --uid e2G7k9EVul4JbfsEYA",
+        shell=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+    # by key
+    result = subprocess.run(
+        "lamin load --key blog/nbproject/elyra-completed-tutorial-pipeline.png",
         shell=True,
         capture_output=True,
     )


### PR DESCRIPTION
Now you can just call:

```shell
lamin load --key mydatasets/mytable.parquet
lamin load --key analysis.ipynb
```

This is parallel to `lamin save` and uses the same component that infers the entity from the suffix.