### PR TITLE
🧪 Skip test_cli_login_api_key

### DIFF
--- a/tests/core/test_login.py
+++ b/tests/core/test_login.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from lamindb_setup import settings
 from lamindb_setup.core._hub_client import connect_hub_with_auth
 from lamindb_setup.core._hub_core import create_api_key
@@ -17,6 +18,7 @@ def test_cli_login():
     assert settings.user.handle == "testuser1"
 
 
+@pytest.mark.skip(reason="Creating more than five API keys is not allowed")
 def test_cli_login_api_key():
     settings._user_settings = None  # this is to refresh a settings instance
     assert settings.user.handle == "testuser1"
@@ -41,5 +43,6 @@ def test_cli_login_api_key():
     assert settings.user.api_key == api_key
 
     hub = connect_hub_with_auth()
+    # doesn't work as the table doesn't have select permissions
     hub.table("api_key").delete().eq("description", "test_cli_login_api_key").execute()
     hub.auth.sign_out({"scope": "local"})


### PR DESCRIPTION
As creating more than 5 api keys is not allowed now, and the test creates api keys for testuser1 on each run, it always fails.