### PR TITLE
Feature: cli to execute shell scripts and executables and track

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -234,6 +234,40 @@ def rewrite_exec_argv(argv: list[str]) -> list[str]:
     return [resolve_lamin_exec_arg(arg) for arg in argv]
 
 
+def _collect_exec_output_paths(
+    argv: list[str], register_outputs: tuple[str, ...]
+) -> list[Path]:
+    output_paths = [Path(output) for output in register_outputs]
+    passthrough_argv = argv[1:]
+    i = 0
+    while i < len(passthrough_argv):
+        arg = passthrough_argv[i]
+        if arg in {"--out", "--output"}:
+            if i + 1 < len(passthrough_argv):
+                value = passthrough_argv[i + 1]
+                if not value.startswith("-"):
+                    output_paths.append(Path(value))
+                    i += 2
+                    continue
+        elif arg.startswith("--out="):
+            output_paths.append(Path(arg.partition("=")[2]))
+        elif arg.startswith("--output="):
+            output_paths.append(Path(arg.partition("=")[2]))
+        i += 1
+    return output_paths
+
+
+def _register_exec_outputs(run, output_paths: list[Path]) -> None:
+    import lamindb as ln
+
+    seen_paths: set[Path] = set()
+    for output_path in output_paths:
+        if output_path in seen_paths or not output_path.exists():
+            continue
+        seen_paths.add(output_path)
+        ln.Artifact(output_path, key=output_path.name, run=run).save()
+
+
 @lamin_group_decorator
 @click.version_option(version=lamindb_version, prog_name="lamindb-core")
 def main():
@@ -356,8 +390,15 @@ def disconnect(here: bool):
 
 @main.command("exec", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
 @click.argument("target", type=str)
+@click.option(
+    "--register-output",
+    "register_outputs",
+    multiple=True,
+    type=str,
+    help="Register an output artifact path after execution.",
+)
 @click.pass_context
-def exec_(ctx: click.Context, target: str):
+def exec_(ctx: click.Context, target: str, register_outputs: tuple[str, ...]):
     """Execute a local script or opaque executable.
 
     The target is launched directly and all remaining argv tokens are passed to the
@@ -366,25 +407,33 @@ def exec_(ctx: click.Context, target: str):
     import lamindb as ln
     from lamindb._finish import save_run_logs
 
-    child_argv = rewrite_exec_argv([target, *ctx.args])
-    target_kind = classify_exec_target(child_argv[0])
-    transform = _prepare_exec_transform(child_argv[0], target_kind)
+    resolved_target = resolve_lamin_exec_arg(target)
+    target_kind = classify_exec_target(resolved_target)
+    transform = _prepare_exec_transform(resolved_target, target_kind)
     run = ln.Run(transform=transform)
     run.started_at = datetime.now(timezone.utc)
     run._status_code = -1
-    run.cli_args = shlex.join(child_argv)
     run.save()
 
+    previous_run = ln.context.run
+    ln.context._run = run
     ln.context._stream_tracker.start(run)
     returncode = 1
     try:
+        child_argv = rewrite_exec_argv([resolved_target, *ctx.args])
+        run.cli_args = shlex.join(child_argv)
+        run.save()
         result = subprocess.run(child_argv, check=False)
         returncode = result.returncode
+        _register_exec_outputs(
+            run, _collect_exec_output_paths(child_argv, register_outputs)
+        )
     finally:
         run._status_code = returncode
         run.finished_at = datetime.now(timezone.utc)
         run.save()
         ln.context._stream_tracker.finish()
+        ln.context._run = previous_run
         save_run_logs(run, save_run=True)
     raise SystemExit(returncode)
 

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -142,7 +142,10 @@ def _probe_exec_version(executable: str) -> str | None:
             capture_output=True,
             check=False,
             text=True,
+            timeout=5,
         )
+    except subprocess.TimeoutExpired:
+        return None
     except OSError:
         return None
 
@@ -203,6 +206,9 @@ def parse_lamin_exec_uri(uri: str) -> tuple[str, str, Path | None]:
             f"Artifact uid must be 16 or 20 characters, got {len(uid)}."
         )
 
+    if not uid.isalnum():
+        raise click.BadParameter("Artifact uid must be alphanumeric.")
+
     if any(part == "" for part in subpath_parts):
         raise click.BadParameter(
             "Expected lamin://<owner>/<instance>/artifact/<uid>[/<subpath>]."
@@ -219,19 +225,79 @@ def _load_exec_artifact(instance_slug: str, uid: str):
     return ln.Artifact.get(uid)
 
 
-def resolve_lamin_exec_arg(arg: str) -> str:
+def parse_mount_storage_mappings(
+    mappings: tuple[str, ...],
+) -> tuple[tuple[str, Path], ...]:
+    parsed_mappings: list[tuple[str, Path]] = []
+    for mapping in mappings:
+        storage_root, separator, mount_root = mapping.partition("=")
+        if not separator or not storage_root or not mount_root:
+            raise click.BadParameter(
+                "Expected --mount-storage <storage-root>=<mount-root>."
+            )
+        parsed_mappings.append((storage_root, Path(mount_root)))
+    return tuple(parsed_mappings)
+
+
+def _resolve_mounted_exec_path(
+    artifact,
+    subpath: Path | None,
+    mount_storage_mappings: tuple[tuple[str, Path], ...],
+) -> Path | None:
+    if not mount_storage_mappings:
+        return None
+
+    from lamindb.core.storage.paths import check_path_is_child_of_root
+    from lamindb_setup.core.upath import UPath
+
+    artifact_storage = getattr(artifact, "storage", None)
+    artifact_raw_path = getattr(artifact, "path", None)
+    if artifact_raw_path is None or artifact_storage is None:
+        return None
+
+    artifact_path = UPath(str(artifact_raw_path))
+
+    for candidate_storage_root, mount_root in mount_storage_mappings:
+        if not check_path_is_child_of_root(artifact_path, candidate_storage_root):
+            continue
+
+        resolved_artifact_path = str(artifact_path.resolve())
+        resolved_storage_root = str(UPath(candidate_storage_root).resolve())
+        relative_path = resolved_artifact_path.removeprefix(resolved_storage_root).lstrip("/")
+
+        mounted_path = mount_root / Path(relative_path)
+        if subpath is not None:
+            mounted_path = mounted_path / subpath
+        if mounted_path.exists():
+            return mounted_path
+
+    return None
+
+
+def resolve_lamin_exec_arg(
+    arg: str, mount_storage_mappings: tuple[tuple[str, Path], ...] = ()
+) -> str:
     if not arg.startswith("lamin://"):
         return arg
 
     instance_slug, uid, subpath = parse_lamin_exec_uri(arg)
-    cache_path = _load_exec_artifact(instance_slug, uid).cache()
+    artifact = _load_exec_artifact(instance_slug, uid)
+    mounted_path = _resolve_mounted_exec_path(
+        artifact, subpath, mount_storage_mappings
+    )
+    if mounted_path is not None:
+        return str(mounted_path)
+
+    cache_path = artifact.cache()
     if subpath is not None:
         cache_path = cache_path / subpath
     return str(cache_path)
 
 
-def rewrite_exec_argv(argv: list[str]) -> list[str]:
-    return [resolve_lamin_exec_arg(arg) for arg in argv]
+def rewrite_exec_argv(
+    argv: list[str], mount_storage_mappings: tuple[tuple[str, Path], ...] = ()
+) -> list[str]:
+    return [resolve_lamin_exec_arg(arg, mount_storage_mappings) for arg in argv]
 
 
 def _collect_exec_output_paths(
@@ -397,8 +463,20 @@ def disconnect(here: bool):
     type=str,
     help="Register an output artifact path after execution.",
 )
+@click.option(
+    "--mount-storage",
+    "mount_storage",
+    multiple=True,
+    type=str,
+    help="Map a storage root to a mounted local root for exec artifact resolution.",
+)
 @click.pass_context
-def exec_(ctx: click.Context, target: str, register_outputs: tuple[str, ...]):
+def exec_(
+    ctx: click.Context,
+    target: str,
+    register_outputs: tuple[str, ...],
+    mount_storage: tuple[str, ...],
+):
     """Execute a local script or opaque executable.
 
     The target is launched directly and all remaining argv tokens are passed to the
@@ -407,7 +485,8 @@ def exec_(ctx: click.Context, target: str, register_outputs: tuple[str, ...]):
     import lamindb as ln
     from lamindb._finish import save_run_logs
 
-    resolved_target = resolve_lamin_exec_arg(target)
+    mount_storage_mappings = parse_mount_storage_mappings(mount_storage)
+    resolved_target = resolve_lamin_exec_arg(target, mount_storage_mappings)
     target_kind = classify_exec_target(resolved_target)
     transform = _prepare_exec_transform(resolved_target, target_kind)
     run = ln.Run(transform=transform)
@@ -420,7 +499,9 @@ def exec_(ctx: click.Context, target: str, register_outputs: tuple[str, ...]):
     ln.context._stream_tracker.start(run)
     returncode = 1
     try:
-        child_argv = rewrite_exec_argv([resolved_target, *ctx.args])
+        child_argv = rewrite_exec_argv(
+            [resolved_target, *ctx.args], mount_storage_mappings
+        )
         run.cli_args = shlex.join(child_argv)
         run.save()
         result = subprocess.run(child_argv, check=False)
@@ -428,6 +509,8 @@ def exec_(ctx: click.Context, target: str, register_outputs: tuple[str, ...]):
         _register_exec_outputs(
             run, _collect_exec_output_paths(child_argv, register_outputs)
         )
+    except FileNotFoundError:
+        returncode = 127
     finally:
         run._status_code = returncode
         run.finished_at = datetime.now(timezone.utc)

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -7,8 +7,8 @@ import shutil
 import subprocess
 import sys
 import warnings
-from datetime import datetime, timezone
 from collections import OrderedDict
+from datetime import datetime, timezone
 from functools import wraps
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -132,7 +132,12 @@ except PackageNotFoundError:
 
 def classify_exec_target(target: str) -> Literal["script", "executable"]:
     """Classify an exec target as a local script or an opaque executable."""
-    return "script" if Path(target).suffix in {".py", ".pyw", ".sh", ".bash", ".zsh", ".r", ".R", ".Rmd", ".qmd"} else "executable"
+    return (
+        "script"
+        if Path(target).suffix
+        in {".py", ".pyw", ".sh", ".bash", ".zsh", ".r", ".R", ".Rmd", ".qmd"}
+        else "executable"
+    )
 
 
 def _probe_exec_version(executable: str) -> str | None:
@@ -164,25 +169,27 @@ def _prepare_exec_transform(target: str, target_kind: Literal["script", "executa
     target_path = Path(target)
     key = target_path.name
     if target_kind == "script":
-        return ln.Transform(
+        transform = ln.Transform(
             key=key,
             source_code=target_path.read_text(),
             kind="script",
-            branch=ln_setup.settings.branch,
-            space=ln_setup.settings.space,
-        ).save()
+        )
+        transform.branch = ln_setup.settings.branch
+        transform.space = ln_setup.settings.space
+        return transform.save()
 
     description = key
     version_output = _probe_exec_version(target)
     if version_output is not None:
         description = f"{key} ({version_output})"
-    return ln.Transform(
+    transform = ln.Transform(
         key=key,
         kind="pipeline",
         description=description,
-        branch=ln_setup.settings.branch,
-        space=ln_setup.settings.space,
-    ).save()
+    )
+    transform.branch = ln_setup.settings.branch
+    transform.space = ln_setup.settings.space
+    return transform.save()
 
 
 def parse_lamin_exec_uri(uri: str) -> tuple[str, str, Path | None]:
@@ -276,7 +283,9 @@ def _resolve_mounted_exec_path(
 
         resolved_artifact_path = str(artifact_path.resolve())
         resolved_storage_root = str(UPath(candidate_storage_root).resolve())
-        relative_path = resolved_artifact_path.removeprefix(resolved_storage_root).lstrip("/")
+        relative_path = resolved_artifact_path.removeprefix(
+            resolved_storage_root
+        ).lstrip("/")
 
         mounted_path = mount_root / Path(relative_path)
         if subpath is not None:
@@ -295,9 +304,7 @@ def resolve_lamin_exec_arg(
 
     instance_slug, uid, subpath = parse_lamin_exec_uri(arg)
     artifact = _load_exec_artifact(instance_slug, uid)
-    mounted_path = _resolve_mounted_exec_path(
-        artifact, subpath, mount_storage_mappings
-    )
+    mounted_path = _resolve_mounted_exec_path(artifact, subpath, mount_storage_mappings)
     if mounted_path is not None:
         return str(mounted_path)
 
@@ -497,6 +504,7 @@ def exec_(
     """
     import lamindb as ln
     from lamindb._finish import save_run_logs
+
     from lamin_cli._settings import read_mount_storage_config
 
     configured_mount_storage = read_mount_storage_config() if not mount_storage else ()

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import inspect
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 import warnings
+from datetime import datetime, timezone
 from collections import OrderedDict
 from functools import wraps
 from importlib.metadata import PackageNotFoundError, version
@@ -131,6 +133,53 @@ except PackageNotFoundError:
 def classify_exec_target(target: str) -> Literal["script", "executable"]:
     """Classify an exec target as a local script or an opaque executable."""
     return "script" if Path(target).suffix in {".py", ".pyw", ".sh", ".bash", ".zsh", ".r", ".R", ".Rmd", ".qmd"} else "executable"
+
+
+def _probe_exec_version(executable: str) -> str | None:
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    version_output = (result.stdout or result.stderr).strip()
+    if not version_output:
+        return None
+    return version_output.splitlines()[0]
+
+
+def _prepare_exec_transform(target: str, target_kind: Literal["script", "executable"]):
+    import lamindb as ln
+
+    target_path = Path(target)
+    key = target_path.name
+    if target_kind == "script":
+        return ln.Transform(
+            key=key,
+            source_code=target_path.read_text(),
+            kind="script",
+            branch=ln_setup.settings.branch,
+            space=ln_setup.settings.space,
+        ).save()
+
+    description = key
+    version_output = _probe_exec_version(target)
+    if version_output is not None:
+        description = f"{key} ({version_output})"
+    return ln.Transform(
+        key=key,
+        kind="pipeline",
+        description=description,
+        branch=ln_setup.settings.branch,
+        space=ln_setup.settings.space,
+    ).save()
 
 
 def parse_lamin_exec_uri(uri: str) -> tuple[str, str, Path | None]:
@@ -314,9 +363,30 @@ def exec_(ctx: click.Context, target: str):
     The target is launched directly and all remaining argv tokens are passed to the
     child process unchanged.
     """
-    _ = classify_exec_target(target)
-    result = subprocess.run(rewrite_exec_argv([target, *ctx.args]), check=False)
-    raise SystemExit(result.returncode)
+    import lamindb as ln
+    from lamindb._finish import save_run_logs
+
+    child_argv = rewrite_exec_argv([target, *ctx.args])
+    target_kind = classify_exec_target(child_argv[0])
+    transform = _prepare_exec_transform(child_argv[0], target_kind)
+    run = ln.Run(transform=transform)
+    run.started_at = datetime.now(timezone.utc)
+    run._status_code = -1
+    run.cli_args = shlex.join(child_argv)
+    run.save()
+
+    ln.context._stream_tracker.start(run)
+    returncode = 1
+    try:
+        result = subprocess.run(child_argv, check=False)
+        returncode = result.returncode
+    finally:
+        run._status_code = returncode
+        run.finished_at = datetime.now(timezone.utc)
+        run.save()
+        ln.context._stream_tracker.finish()
+        save_run_logs(run, save_run=True)
+    raise SystemExit(returncode)
 
 
 # fmt: off

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -133,6 +133,58 @@ def classify_exec_target(target: str) -> Literal["script", "executable"]:
     return "script" if Path(target).suffix in {".py", ".pyw", ".sh", ".bash", ".zsh", ".r", ".R", ".Rmd", ".qmd"} else "executable"
 
 
+def parse_lamin_exec_uri(uri: str) -> tuple[str, str, Path | None]:
+    if not uri.startswith("lamin://"):
+        raise click.BadParameter("Expected a lamin:// URI.")
+
+    parts = uri.removeprefix("lamin://").split("/")
+    if len(parts) < 4:
+        raise click.BadParameter(
+            "Expected lamin://<owner>/<instance>/artifact/<uid>[/<subpath>]."
+        )
+
+    owner, instance, entity, uid, *subpath_parts = parts
+    if not owner or not instance or entity != "artifact":
+        raise click.BadParameter(
+            "Expected lamin://<owner>/<instance>/artifact/<uid>[/<subpath>]."
+        )
+
+    if len(uid) not in {16, 20}:
+        raise click.BadParameter(
+            f"Artifact uid must be 16 or 20 characters, got {len(uid)}."
+        )
+
+    if any(part == "" for part in subpath_parts):
+        raise click.BadParameter(
+            "Expected lamin://<owner>/<instance>/artifact/<uid>[/<subpath>]."
+        )
+
+    subpath = Path(*subpath_parts) if subpath_parts else None
+    return f"{owner}/{instance}", uid, subpath
+
+
+def _load_exec_artifact(instance_slug: str, uid: str):
+    ln_setup.connect(instance_slug)
+    import lamindb as ln
+
+    return ln.Artifact.get(uid)
+
+
+def resolve_lamin_exec_arg(arg: str) -> str:
+    if not arg.startswith("lamin://"):
+        return arg
+
+    instance_slug, uid, subpath = parse_lamin_exec_uri(arg)
+    cache_path = _load_exec_artifact(instance_slug, uid).cache()
+    if subpath is not None:
+        cache_path = cache_path / subpath
+    return str(cache_path)
+
+
+def rewrite_exec_argv(argv: list[str]) -> list[str]:
+    return [resolve_lamin_exec_arg(arg) for arg in argv]
+
+
 @lamin_group_decorator
 @click.version_option(version=lamindb_version, prog_name="lamindb-core")
 def main():
@@ -263,7 +315,7 @@ def exec_(ctx: click.Context, target: str):
     child process unchanged.
     """
     _ = classify_exec_target(target)
-    result = subprocess.run([target, *ctx.args], check=False)
+    result = subprocess.run(rewrite_exec_argv([target, *ctx.args]), check=False)
     raise SystemExit(result.returncode)
 
 

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -228,14 +228,23 @@ def _load_exec_artifact(instance_slug: str, uid: str):
 def parse_mount_storage_mappings(
     mappings: tuple[str, ...],
 ) -> tuple[tuple[str, Path], ...]:
+    from lamindb_setup.core.upath import UPath
+
     parsed_mappings: list[tuple[str, Path]] = []
+    seen_storage_roots: set[str] = set()
     for mapping in mappings:
         storage_root, separator, mount_root = mapping.partition("=")
         if not separator or not storage_root or not mount_root:
             raise click.BadParameter(
                 "Expected --mount-storage <storage-root>=<mount-root>."
             )
-        parsed_mappings.append((storage_root, Path(mount_root)))
+        normalized_storage_root = str(UPath(storage_root).resolve())
+        if normalized_storage_root in seen_storage_roots:
+            raise click.BadParameter(
+                "Duplicate --mount-storage storage root after normalization."
+            )
+        seen_storage_roots.add(normalized_storage_root)
+        parsed_mappings.append((normalized_storage_root, Path(mount_root)))
     return tuple(parsed_mappings)
 
 
@@ -257,7 +266,11 @@ def _resolve_mounted_exec_path(
 
     artifact_path = UPath(str(artifact_raw_path))
 
-    for candidate_storage_root, mount_root in mount_storage_mappings:
+    for candidate_storage_root, mount_root in sorted(
+        mount_storage_mappings,
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
         if not check_path_is_child_of_root(artifact_path, candidate_storage_root):
             continue
 
@@ -487,9 +500,16 @@ def exec_(
     from lamin_cli._settings import read_mount_storage_config
 
     configured_mount_storage = read_mount_storage_config() if not mount_storage else ()
-    mount_storage_mappings = parse_mount_storage_mappings(
-        mount_storage or configured_mount_storage
-    )
+    try:
+        mount_storage_mappings = parse_mount_storage_mappings(
+            mount_storage or configured_mount_storage
+        )
+    except click.BadParameter as error:
+        if configured_mount_storage:
+            raise click.BadParameter(
+                "Invalid machine-local mount-storage mapping. Fix it with `lamin settings mount-storage set ...` or `lamin settings mount-storage unset`."
+            ) from error
+        raise
     resolved_target = resolve_lamin_exec_arg(target, mount_storage_mappings)
     target_kind = classify_exec_target(resolved_target)
     transform = _prepare_exec_transform(resolved_target, target_kind)

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import os
 import shutil
+import subprocess
 import sys
 import warnings
 from collections import OrderedDict
@@ -37,6 +38,10 @@ COMMAND_GROUPS = {
         {
             "name": "Configure your environment",
             "commands": ["connect", "info", "init", "disconnect"],
+        },
+        {
+            "name": "Execute programs",
+            "commands": ["exec"],
         },
         {
             "name": "Save, load, create & delete",
@@ -121,6 +126,11 @@ try:
     lamindb_version = version("lamindb-core")
 except PackageNotFoundError:
     lamindb_version = "lamindb-core installation not found"
+
+
+def classify_exec_target(target: str) -> Literal["script", "executable"]:
+    """Classify an exec target as a local script or an opaque executable."""
+    return "script" if Path(target).suffix in {".py", ".pyw", ".sh", ".bash", ".zsh", ".r", ".R", ".Rmd", ".qmd"} else "executable"
 
 
 @lamin_group_decorator
@@ -241,6 +251,20 @@ def disconnect(here: bool):
     → Python/R alternative: {func}`~lamindb.setup.disconnect`
     """
     return disconnect_(here=here)
+
+
+@main.command("exec", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("target", type=str)
+@click.pass_context
+def exec_(ctx: click.Context, target: str):
+    """Execute a local script or opaque executable.
+
+    The target is launched directly and all remaining argv tokens are passed to the
+    child process unchanged.
+    """
+    _ = classify_exec_target(target)
+    result = subprocess.run([target, *ctx.args], check=False)
+    raise SystemExit(result.returncode)
 
 
 # fmt: off

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -484,8 +484,12 @@ def exec_(
     """
     import lamindb as ln
     from lamindb._finish import save_run_logs
+    from lamin_cli._settings import read_mount_storage_config
 
-    mount_storage_mappings = parse_mount_storage_mappings(mount_storage)
+    configured_mount_storage = read_mount_storage_config() if not mount_storage else ()
+    mount_storage_mappings = parse_mount_storage_mappings(
+        mount_storage or configured_mount_storage
+    )
     resolved_target = resolve_lamin_exec_arg(target, mount_storage_mappings)
     target_kind = classify_exec_target(resolved_target)
     transform = _prepare_exec_transform(resolved_target, target_kind)

--- a/lamin_cli/_save.py
+++ b/lamin_cli/_save.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
+from typing import Any, cast
 
 import click
 import lamindb_setup as ln_setup
@@ -193,13 +194,14 @@ def _save_readme_block(
     import lamindb as ln
 
     content = ppath.read_text(encoding="utf-8")
-    ln.models.Block(
+    block = ln.models.Block(
         key="README.md",
         content=content,
         kind="readme",
-        branch=branch,
-        space=space,
-    ).save()
+    )
+    block.branch = branch
+    block.space = space
+    block.save()
     logger.important("saved README block")
 
 
@@ -505,11 +507,11 @@ def save(
                 description = parse_title_r_notebook(content)
             else:
                 description = None
-            transform = ln.Transform(
+            transform = cast(Any, ln.Transform)(
                 uid=uid,
                 description=description,
                 key=key,
-                type="script" if ppath.suffix in {".R", ".py", ".sh"} else "notebook",
+                kind="script" if ppath.suffix in {".R", ".py", ".sh"} else "notebook",
                 revises=revises,
                 reference=reference,
                 reference_type=reference_type,

--- a/lamin_cli/_settings.py
+++ b/lamin_cli/_settings.py
@@ -9,10 +9,23 @@ else:
     import rich_click as click
 
 
+def mount_storage_config_path() -> Path:
+    from lamindb_setup import settings as settings_
+
+    return settings_.settings_dir / "exec-mount-storage.txt"
+
+
+def read_mount_storage_config() -> tuple[str, ...]:
+    path = mount_storage_config_path()
+    if not path.exists():
+        return ()
+    return tuple(line.strip() for line in path.read_text().splitlines() if line.strip())
+
+
 @click.group(invoke_without_command=True)
 @click.pass_context
 def settings(ctx):
-    """Manage development, cache, modules, branch, and space settings.
+    """Manage development, cache, modules, branch, space, and exec mount-storage settings.
 
     Get or set a setting by name:
 
@@ -21,6 +34,7 @@ def settings(ctx):
     - `modules` → environment schema modules {attr}`~lamindb.setup.core.SetupSettings.modules`
     - `branch` → branch {attr}`~lamindb.setup.core.SetupSettings.branch`
     - `space` → space {attr}`~lamindb.setup.core.SetupSettings.space`
+    - `mount-storage` → machine-local exec mount mappings for `lamin exec`
 
     Display via [lamin info](https://docs.lamin.ai/cli#info)
 
@@ -46,6 +60,10 @@ def settings(ctx):
     # space
     lamin settings space get
     lamin settings space set all
+    # exec mount-storage
+    lamin settings mount-storage get
+    lamin settings mount-storage set s3://bucket/prefix=/mount/root
+    lamin settings mount-storage unset
     ```
 
     → Python/R alternative: {attr}`~lamindb.setup.core.SetupSettings.dev_dir`, {attr}`~lamindb.setup.core.SetupSettings.cache_dir`, {attr}`~lamindb.setup.core.SetupSettings.modules`, {attr}`~lamindb.setup.core.SetupSettings.branch`, and {attr}`~lamindb.setup.core.SetupSettings.space`
@@ -138,6 +156,44 @@ def modules_unset():
 
 
 settings.add_command(modules_group)
+
+
+# -----------------------------------------------------------------------------
+# mount-storage group (pattern: lamin settings mount-storage get/set)
+# -----------------------------------------------------------------------------
+
+
+@click.group("mount-storage")
+def mount_storage_group():
+    """Get or set machine-local exec mount-storage mappings."""
+
+
+@mount_storage_group.command("get")
+def mount_storage_get():
+    """Show current machine-local exec mount-storage mappings."""
+    mappings = read_mount_storage_config()
+    click.echo("\n".join(mappings) if mappings else "None")
+
+
+@mount_storage_group.command("set")
+@click.argument("values", nargs=-1, type=str)
+def mount_storage_set(values: tuple[str, ...]):
+    """Set machine-local exec mount-storage mappings."""
+    from lamin_cli.__main__ import parse_mount_storage_mappings
+
+    if not values:
+        raise click.UsageError("Provide at least one <storage-root>=<mount-root> mapping.")
+    parse_mount_storage_mappings(values)
+    mount_storage_config_path().write_text("\n".join(values) + "\n")
+
+
+@mount_storage_group.command("unset")
+def mount_storage_unset():
+    """Unset machine-local exec mount-storage mappings."""
+    mount_storage_config_path().unlink(missing_ok=True)
+
+
+settings.add_command(mount_storage_group)
 
 
 # -----------------------------------------------------------------------------

--- a/lamin_cli/_settings.py
+++ b/lamin_cli/_settings.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 if os.environ.get("NO_RICH"):
     import click as click
@@ -182,7 +185,9 @@ def mount_storage_set(values: tuple[str, ...]):
     from lamin_cli.__main__ import parse_mount_storage_mappings
 
     if not values:
-        raise click.UsageError("Provide at least one <storage-root>=<mount-root> mapping.")
+        raise click.UsageError(
+            "Provide at least one <storage-root>=<mount-root> mapping."
+        )
     parse_mount_storage_mappings(values)
     mount_storage_config_path().write_text("\n".join(values) + "\n")
 

--- a/tests/core/test_exec.py
+++ b/tests/core/test_exec.py
@@ -12,9 +12,17 @@ from lamin_cli.__main__ import classify_exec_target, main
 
 def _delete_exec_records(key: str) -> None:
     for run in ln.Run.filter(transform__key=key).all():
+        for output_artifact in list(run.output_artifacts.all()):
+            output_artifact.delete(permanent=True)
         run.delete(permanent=True)
     for transform in ln.Transform.filter(key=key).all():
         transform.delete(permanent=True)
+
+
+def _delete_exec_artifact_for_path(path: Path) -> None:
+    artifact = ln.Artifact.filter(key=path.name).one_or_none()
+    if artifact is not None:
+        artifact.delete(permanent=True)
 
 
 def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
@@ -176,3 +184,241 @@ def test_exec_persists_exact_cli_args_and_child_status_with_logs(
         assert "hello stderr from child" in logs_path.read_text()
     finally:
         _delete_exec_records(target.name)
+
+
+def test_exec_registers_explicit_outputs_and_links_them_to_run(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        output_path.write_text("registered output\n")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "explicit-output-script.py"
+    output_path = tmp_path / "explicit-output.txt"
+    target.write_text("print('save output')\n")
+
+    _delete_exec_records(target.name)
+    _delete_exec_artifact_for_path(output_path)
+    try:
+        result = CliRunner().invoke(
+            main,
+            [
+                "exec",
+                str(target),
+                "--register-output",
+                str(output_path),
+                "--flag",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        run = ln.Transform.get(key=target.name).latest_run
+        outputs = list(run.output_artifacts.all())
+
+        assert len(outputs) == 1
+        assert outputs[0].run_id == run.id
+        assert outputs[0].key == output_path.name
+    finally:
+        _delete_exec_records(target.name)
+        _delete_exec_artifact_for_path(output_path)
+
+
+def test_exec_infers_output_registration_from_passthrough_output_flags(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        assert command == [str(target), "--output", str(output_path)]
+        output_path.write_text("inferred output\n")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "inferred-output-script.py"
+    output_path = tmp_path / "inferred-output.txt"
+    target.write_text("print('infer output')\n")
+
+    _delete_exec_records(target.name)
+    _delete_exec_artifact_for_path(output_path)
+    try:
+        result = CliRunner().invoke(main, ["exec", str(target), "--output", str(output_path)])
+
+        assert result.exit_code == 0, result.output
+
+        run = ln.Transform.get(key=target.name).latest_run
+        outputs = list(run.output_artifacts.all())
+
+        assert len(outputs) == 1
+        assert outputs[0].key == output_path.name
+    finally:
+        _delete_exec_records(target.name)
+        _delete_exec_artifact_for_path(output_path)
+
+
+def test_exec_registers_multiple_explicit_outputs(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        first_output.write_text("first\n")
+        second_output.write_text("second\n")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "multiple-outputs-script.py"
+    first_output = tmp_path / "multiple-first.txt"
+    second_output = tmp_path / "multiple-second.txt"
+    target.write_text("print('many outputs')\n")
+
+    _delete_exec_records(target.name)
+    _delete_exec_artifact_for_path(first_output)
+    _delete_exec_artifact_for_path(second_output)
+    try:
+        result = CliRunner().invoke(
+            main,
+            [
+                "exec",
+                str(target),
+                "--register-output",
+                str(first_output),
+                "--register-output",
+                str(second_output),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        run = ln.Transform.get(key=target.name).latest_run
+        output_keys = {artifact.key for artifact in run.output_artifacts.all()}
+
+        assert output_keys == {first_output.name, second_output.name}
+    finally:
+        _delete_exec_records(target.name)
+        _delete_exec_artifact_for_path(first_output)
+        _delete_exec_artifact_for_path(second_output)
+
+
+def test_exec_deduplicates_explicit_and_inferred_outputs(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        output_path.write_text("dedup output\n")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "dedup-output-script.py"
+    output_path = tmp_path / "dedup-output.txt"
+    target.write_text("print('dedup output')\n")
+
+    _delete_exec_records(target.name)
+    _delete_exec_artifact_for_path(output_path)
+    try:
+        result = CliRunner().invoke(
+            main,
+            [
+                "exec",
+                str(target),
+                "--register-output",
+                str(output_path),
+                "--output",
+                str(output_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        run = ln.Transform.get(key=target.name).latest_run
+        output_keys = [artifact.key for artifact in run.output_artifacts.all()]
+
+        assert output_keys == [output_path.name]
+    finally:
+        _delete_exec_records(target.name)
+        _delete_exec_artifact_for_path(output_path)
+
+
+def test_exec_skips_missing_registered_outputs(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "missing-output-script.py"
+    output_path = tmp_path / "missing-output.txt"
+    target.write_text("print('missing output')\n")
+
+    _delete_exec_records(target.name)
+    _delete_exec_artifact_for_path(output_path)
+    try:
+        result = CliRunner().invoke(
+            main,
+            ["exec", str(target), "--register-output", str(output_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        run = ln.Transform.get(key=target.name).latest_run
+
+        assert list(run.output_artifacts.all()) == []
+    finally:
+        _delete_exec_records(target.name)
+        _delete_exec_artifact_for_path(output_path)
+
+
+def test_exec_links_lamin_uri_inputs_to_the_active_run(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        output_path.write_text("output from uri input\n")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    input_path = tmp_path / "uri-input.txt"
+    input_path.write_text("uri input\n")
+    input_artifact = ln.Artifact(input_path, key=input_path.name).save()
+
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact",
+        lambda instance, uid: input_artifact,
+    )
+
+    target = tmp_path / "uri-input-script.py"
+    output_path = tmp_path / "uri-input-output.txt"
+    target.write_text("print('use uri input')\n")
+    uri = f"lamin://laminlabs/demo/artifact/{input_artifact.uid}"
+
+    _delete_exec_records(target.name)
+    _delete_exec_artifact_for_path(output_path)
+    try:
+        result = CliRunner().invoke(
+            main,
+            [
+                "exec",
+                str(target),
+                "--register-output",
+                str(output_path),
+                "--input",
+                uri,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        run = ln.Transform.get(key=target.name).latest_run
+
+        assert list(run.input_artifacts.values_list("uid", flat=True)) == [input_artifact.uid]
+    finally:
+        input_artifact.delete(permanent=True)
+        _delete_exec_records(target.name)
+        _delete_exec_artifact_for_path(output_path)

--- a/tests/core/test_exec.py
+++ b/tests/core/test_exec.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from lamin_cli.__main__ import classify_exec_target, main
+
+
+def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
+    recorded: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "run-me.py"
+    target.write_text("print('hello')\n")
+
+    result = CliRunner().invoke(main, ["exec", str(target), "--flag", "value", "-x"])
+
+    assert result.exit_code == 0, result.output
+    assert recorded["command"] == [str(target), "--flag", "value", "-x"]
+    assert recorded["kwargs"] == {"check": False}
+
+
+def test_exec_propagates_child_exit_code(monkeypatch, tmp_path: Path):
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 17)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "run-me.py"
+    target.write_text("print('hello')\n")
+
+    result = CliRunner().invoke(main, ["exec", str(target)])
+
+    assert result.exit_code == 17
+
+
+def test_exec_classifies_local_script_vs_opaque_executable(tmp_path: Path):
+    script = tmp_path / "run-me.py"
+    script.write_text("print('hello')\n")
+
+    executable = tmp_path / "run-me"
+    executable.write_text("#!/bin/sh\necho hello\n")
+    executable.chmod(executable.stat().st_mode | 0o111)
+
+    assert classify_exec_target(str(script)) == "script"
+    assert classify_exec_target(str(executable)) == "executable"
+    assert classify_exec_target("python") == "executable"

--- a/tests/core/test_exec.py
+++ b/tests/core/test_exec.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import sys
 import subprocess
 from pathlib import Path
 
+import lamindb as ln
 from click.testing import CliRunner
 
 from lamin_cli.__main__ import classify_exec_target, main
+
+
+def _delete_exec_records(key: str) -> None:
+    for run in ln.Run.filter(transform__key=key).all():
+        run.delete(permanent=True)
+    for transform in ln.Transform.filter(key=key).all():
+        transform.delete(permanent=True)
 
 
 def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
@@ -53,3 +62,117 @@ def test_exec_classifies_local_script_vs_opaque_executable(tmp_path: Path):
     assert classify_exec_target(str(script)) == "script"
     assert classify_exec_target(str(executable)) == "executable"
     assert classify_exec_target("python") == "executable"
+
+
+def test_exec_creates_and_reuses_source_backed_transform(monkeypatch, tmp_path: Path):
+    recorded: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        recorded.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "tracked-script.py"
+    target.write_text("print('hello from script')\n")
+
+    _delete_exec_records(target.name)
+    try:
+        result = CliRunner().invoke(main, ["exec", str(target), "--first"])
+        assert result.exit_code == 0, result.output
+
+        first_transform = ln.Transform.get(key=target.name)
+        first_run = first_transform.latest_run
+
+        assert first_transform.kind == "script"
+        assert first_transform.source_code == target.read_text()
+        assert first_run.cli_args == f"{target} --first"
+
+        result = CliRunner().invoke(main, ["exec", str(target), "--second"])
+        assert result.exit_code == 0, result.output
+
+        second_transform = ln.Transform.get(key=target.name)
+        runs = list(ln.Run.filter(transform=second_transform).order_by("started_at"))
+
+        assert second_transform.id == first_transform.id
+        assert [run.cli_args for run in runs] == [
+            f"{target} --first",
+            f"{target} --second",
+        ]
+        assert recorded == [[str(target), "--first"], [str(target), "--second"]]
+    finally:
+        _delete_exec_records(target.name)
+
+
+def test_exec_creates_metadata_only_transform_for_executable_and_captures_version(
+    monkeypatch,
+):
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == ["python", "--version"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="Python 3.14.2\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    _delete_exec_records("python")
+    try:
+        result = CliRunner().invoke(main, ["exec", "python", "--debug"])
+
+        assert result.exit_code == 0, result.output
+
+        transform = ln.Transform.get(key="python")
+        run = transform.latest_run
+
+        assert transform.kind == "pipeline"
+        assert transform.source_code is None
+        assert transform.description == "python (Python 3.14.2)"
+        assert run.cli_args == "python --debug"
+        assert calls == [["python", "--version"], ["python", "--debug"]]
+    finally:
+        _delete_exec_records("python")
+
+
+def test_exec_persists_exact_cli_args_and_child_status_with_logs(
+    monkeypatch,
+    tmp_path: Path,
+):
+    def fake_run(command, **kwargs):
+        print("hello stdout from child")
+        print("hello stderr from child", file=sys.stderr)
+        return subprocess.CompletedProcess(command, 17)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "logged-script.py"
+    target.write_text("print('log me')\n")
+
+    _delete_exec_records(target.name)
+    try:
+        result = CliRunner().invoke(
+            main,
+            ["exec", str(target), "--message", "two words", "--flag"],
+        )
+
+        assert result.exit_code == 17
+
+        transform = ln.Transform.get(key=target.name)
+        run = transform.latest_run
+
+        assert run.cli_args == f"{target} --message 'two words' --flag"
+        assert run.started_at is not None
+        assert run.finished_at is not None
+        assert run._status_code == 17
+        assert run.report is not None
+        logs_path = run.report.cache()
+        assert "hello stdout from child" in logs_path.read_text()
+        assert "hello stderr from child" in logs_path.read_text()
+    finally:
+        _delete_exec_records(target.name)

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -12,6 +12,8 @@ from click.testing import CliRunner
 from lamin_cli.__main__ import (
     classify_exec_target,
     main,
+    _probe_exec_version,
+    parse_mount_storage_mappings,
     parse_lamin_exec_uri,
     rewrite_exec_argv,
 )
@@ -26,6 +28,13 @@ def connected_instance(tmp_path_factory):
     storage = tmp_path_factory.mktemp("lamin-cli-exec-storage")
     ln.setup.init(storage=str(storage), name="lamin-cli-exec-tests")
     yield
+
+
+def _delete_exec_records(key: str) -> None:
+    for run in ln.Run.filter(transform__key=key).all():
+        run.delete(permanent=True)
+    for transform in ln.Transform.filter(key=key).all():
+        transform.delete(permanent=True)
 
 
 def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
@@ -46,6 +55,31 @@ def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
     assert result.exit_code == 0, result.output
     assert recorded["command"] == [str(target), "--flag", "value", "-x"]
     assert recorded["kwargs"] == {"check": False}
+
+
+def test_probe_exec_version_times_out(monkeypatch):
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    assert _probe_exec_version("python") is None
+
+
+def test_exec_returns_clean_exit_code_for_missing_executable(monkeypatch):
+    def fake_run(command, **kwargs):
+        raise FileNotFoundError(command[0])
+
+    monkeypatch.setattr("lamin_cli.__main__._probe_exec_version", lambda executable: None)
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    _delete_exec_records("missing-command")
+    try:
+        result = CliRunner().invoke(main, ["exec", "missing-command"])
+
+        assert result.exit_code == 127
+    finally:
+        _delete_exec_records("missing-command")
 
 
 def test_exec_propagates_child_exit_code(monkeypatch, tmp_path: Path):
@@ -97,8 +131,9 @@ def test_parse_lamin_exec_uri(uri: str, expected: tuple[str, str, Path | None]):
     [
         "https://lamin.ai/laminlabs/demo/artifact/1234567890abcdef",
         "lamin://laminlabs/demo/transform/1234567890abcdef",
-        "lamin://laminlabs/demo/artifact/not-a-valid-uid",
+        "lamin://laminlabs/demo/artifact/1234567890abc-de",
         "lamin://laminlabs/demo/artifact/1234567890abcdef/",
+        "lamin://laminlabs/demo/artifact/1234567890abcde!/path/to/data.csv",
     ],
 )
 def test_parse_lamin_exec_uri_rejects_invalid_inputs(uri: str):
@@ -125,6 +160,189 @@ def test_rewrite_exec_argv_replaces_lamin_uri_with_cached_path(monkeypatch, tmp_
         "value",
         str(cache_path),
     ]
+
+
+def test_rewrite_exec_argv_prefers_mounted_storage_path_when_present(
+    monkeypatch, tmp_path: Path
+):
+    storage_root = tmp_path / "storage-root"
+    artifact_path = storage_root / "dataset" / "input.csv"
+    mount_root = tmp_path / "mount-root"
+    mounted_path = mount_root / "dataset" / "input.csv"
+    mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    mounted_path.write_text("mounted")
+    cache_path = tmp_path / "artifact-cache"
+
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: cache_path,
+    )
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
+
+    assert rewrite_exec_argv(
+        argv,
+        parse_mount_storage_mappings((f"{storage_root}={mount_root}",)),
+    ) == [str(mounted_path)]
+
+
+def test_rewrite_exec_argv_falls_back_to_cache_when_mount_path_missing(
+    monkeypatch, tmp_path: Path
+):
+    storage_root = tmp_path / "storage-root"
+    artifact_path = storage_root / "dataset" / "input.csv"
+    mount_root = tmp_path / "mount-root"
+    cache_path = tmp_path / "artifact-cache"
+
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: cache_path,
+    )
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
+
+    assert rewrite_exec_argv(
+        argv,
+        parse_mount_storage_mappings((f"{storage_root}={mount_root}",)),
+    ) == [str(cache_path)]
+
+
+def test_rewrite_exec_argv_applies_optional_subpath_to_mounted_roots(
+    monkeypatch, tmp_path: Path
+):
+    storage_root = tmp_path / "storage-root"
+    artifact_path = storage_root / "dataset"
+    mount_root = tmp_path / "mount-root"
+    mounted_path = mount_root / "dataset" / "nested" / "input.csv"
+    mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    mounted_path.write_text("mounted")
+    cache_path = tmp_path / "artifact-cache"
+
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: cache_path,
+    )
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef/nested/input.csv"]
+
+    assert rewrite_exec_argv(
+        argv,
+        parse_mount_storage_mappings((f"{storage_root}={mount_root}",)),
+    ) == [str(mounted_path)]
+
+
+def test_rewrite_exec_argv_supports_repeated_mount_mappings(monkeypatch, tmp_path: Path):
+    first_storage_root = tmp_path / "storage-root-a"
+    second_storage_root = tmp_path / "storage-root-b"
+    artifact_path = second_storage_root / "dataset" / "input.csv"
+    first_mount_root = tmp_path / "mount-root-a"
+    second_mount_root = tmp_path / "mount-root-b"
+    mounted_path = second_mount_root / "dataset" / "input.csv"
+    mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    mounted_path.write_text("mounted")
+    cache_path = tmp_path / "artifact-cache"
+
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=second_storage_root),
+        cache=lambda: cache_path,
+    )
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
+
+    assert rewrite_exec_argv(
+        argv,
+        parse_mount_storage_mappings(
+            (
+                f"{first_storage_root}={first_mount_root}",
+                f"{second_storage_root}={second_mount_root}",
+            )
+        ),
+    ) == [str(mounted_path)]
+
+
+def test_rewrite_exec_argv_supports_s3_mount_storage_mappings(
+    monkeypatch, tmp_path: Path
+):
+    storage_root = "s3://bucket/prefix"
+    artifact_path = "s3://bucket/prefix/dataset/input.csv"
+    mount_root = tmp_path / "mount-root"
+    mounted_path = mount_root / "dataset" / "input.csv"
+    mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    mounted_path.write_text("mounted")
+    cache_path = tmp_path / "artifact-cache"
+
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: cache_path,
+    )
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
+
+    assert rewrite_exec_argv(
+        argv,
+        parse_mount_storage_mappings((f"{storage_root}={mount_root}",)),
+    ) == [str(mounted_path)]
+
+
+def test_exec_mount_storage_option_rewrites_target_before_launch(
+    monkeypatch, tmp_path: Path
+):
+    recorded: dict[str, object] = {}
+
+    storage_root = "s3://bucket/prefix"
+    artifact_path = "s3://bucket/prefix/dataset/script.py"
+    mount_root = tmp_path / "mount-root"
+    mounted_path = mount_root / "dataset" / "script.py"
+    mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    mounted_path.write_text("print('mounted script')\n")
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: tmp_path / "artifact-cache",
+    )
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--mount-storage",
+            f"{storage_root}={mount_root}",
+            "lamin://laminlabs/demo/artifact/1234567890abcdef",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded["command"] == [str(mounted_path)]
+    assert recorded["kwargs"] == {"check": False}
+
+
+@pytest.mark.parametrize("mapping", ["missing-separator", "=mount-root", "storage-root="])
+def test_parse_mount_storage_mappings_rejects_invalid_syntax(mapping: str):
+    with pytest.raises(click.BadParameter):
+        parse_mount_storage_mappings((mapping,))
 
 
 def test_exec_rewrites_lamin_uri_before_launch(monkeypatch, tmp_path: Path):

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import subprocess
+from types import SimpleNamespace
 from pathlib import Path
 
+import click
+import pytest
 from click.testing import CliRunner
 
-from lamin_cli.__main__ import classify_exec_target, main
+from lamin_cli.__main__ import (
+    classify_exec_target,
+    main,
+    parse_lamin_exec_uri,
+    rewrite_exec_argv,
+)
 
 
 def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
@@ -53,3 +61,82 @@ def test_exec_classifies_local_script_vs_opaque_executable(tmp_path: Path):
     assert classify_exec_target(str(script)) == "script"
     assert classify_exec_target(str(executable)) == "executable"
     assert classify_exec_target("python") == "executable"
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        (
+            "lamin://laminlabs/demo/artifact/1234567890abcdef/path/to/data.csv",
+            ("laminlabs/demo", "1234567890abcdef", Path("path/to/data.csv")),
+        ),
+        (
+            "lamin://laminlabs/demo/artifact/1234567890abcdefghij",
+            ("laminlabs/demo", "1234567890abcdefghij", None),
+        ),
+    ],
+)
+def test_parse_lamin_exec_uri(uri: str, expected: tuple[str, str, Path | None]):
+    assert parse_lamin_exec_uri(uri) == expected
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://lamin.ai/laminlabs/demo/artifact/1234567890abcdef",
+        "lamin://laminlabs/demo/transform/1234567890abcdef",
+        "lamin://laminlabs/demo/artifact/not-a-valid-uid",
+        "lamin://laminlabs/demo/artifact/1234567890abcdef/",
+    ],
+)
+def test_parse_lamin_exec_uri_rejects_invalid_inputs(uri: str):
+    with pytest.raises(click.BadParameter):
+        parse_lamin_exec_uri(uri)
+
+
+def test_rewrite_exec_argv_replaces_lamin_uri_with_cached_path(monkeypatch, tmp_path: Path):
+    cache_path = tmp_path / "artifact-cache"
+    artifact = SimpleNamespace(cache=lambda: cache_path)
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = [
+        "lamin://laminlabs/demo/artifact/1234567890abcdef/path/to/data.csv",
+        "--flag",
+        "value",
+        "lamin://laminlabs/demo/artifact/1234567890abcdefghij",
+    ]
+
+    assert rewrite_exec_argv(argv) == [
+        str(cache_path / "path/to/data.csv"),
+        "--flag",
+        "value",
+        str(cache_path),
+    ]
+
+
+def test_exec_rewrites_lamin_uri_before_launch(monkeypatch, tmp_path: Path):
+    recorded: dict[str, object] = {}
+
+    cache_path = tmp_path / "artifact-cache"
+    artifact = SimpleNamespace(cache=lambda: cache_path)
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = "lamin://laminlabs/demo/artifact/1234567890abcdef/path/to/script.py"
+
+    result = CliRunner().invoke(main, ["exec", target, "--input", target])
+
+    assert result.exit_code == 0, result.output
+    assert recorded["command"] == [
+        str(cache_path / "path/to/script.py"),
+        "--input",
+        str(cache_path / "path/to/script.py"),
+    ]
+    assert recorded["kwargs"] == {"check": False}

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -316,6 +316,43 @@ def test_rewrite_exec_argv_supports_s3_mount_storage_mappings(
     ) == [str(mounted_path)]
 
 
+def test_rewrite_exec_argv_prefers_most_specific_mount_storage_mapping(
+    monkeypatch, tmp_path: Path
+):
+    broader_storage_root = "s3://bucket"
+    specific_storage_root = "s3://bucket/prefix"
+    artifact_path = "s3://bucket/prefix/dataset/input.csv"
+    broader_mount_root = tmp_path / "mount-root-broader"
+    broader_mounted_path = broader_mount_root / "prefix" / "dataset" / "input.csv"
+    broader_mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    broader_mounted_path.write_text("broader")
+    specific_mount_root = tmp_path / "mount-root-specific"
+    specific_mounted_path = specific_mount_root / "dataset" / "input.csv"
+    specific_mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    specific_mounted_path.write_text("specific")
+    cache_path = tmp_path / "artifact-cache"
+
+    artifact = SimpleNamespace(
+        path=artifact_path,
+        storage=SimpleNamespace(root=specific_storage_root),
+        cache=lambda: cache_path,
+    )
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+
+    argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
+
+    assert rewrite_exec_argv(
+        argv,
+        parse_mount_storage_mappings(
+            (
+                f"{broader_storage_root}={broader_mount_root}",
+                f"{specific_storage_root}={specific_mount_root}",
+            )
+        ),
+    ) == [str(specific_mounted_path)]
+
+
 def test_exec_mount_storage_option_rewrites_target_before_launch(
     monkeypatch, tmp_path: Path
 ):
@@ -513,6 +550,36 @@ def test_settings_mount_storage_stays_machine_local(tmp_path: Path):
     assert _mount_storage_config_path().parent == ln_setup.settings.settings_dir
     assert current_instance_settings_file().read_text() == current_instance_before
     assert instance_settings_path.read_text() == instance_settings_before
+
+
+def test_settings_mount_storage_rejects_duplicate_normalized_storage_roots(
+    tmp_path: Path,
+):
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "settings",
+            "mount-storage",
+            "set",
+            f"s3://bucket/prefix={tmp_path / 'mount-a'}",
+            f"s3://bucket/prefix/={tmp_path / 'mount-b'}",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Duplicate --mount-storage storage root" in result.output
+
+
+def test_exec_reports_invalid_machine_local_mount_storage_config(tmp_path: Path):
+    _mount_storage_config_path().write_text("missing-separator\n")
+
+    result = CliRunner().invoke(main, ["exec", "python"])
+
+    assert result.exit_code != 0
+    assert "Invalid machine-local mount-storage mapping" in result.output
+    assert "lamin settings mount-storage set" in result.output
 
 
 @pytest.mark.parametrize("mapping", ["missing-separator", "=mount-root", "storage-root="])

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from lamin_cli.__main__ import classify_exec_target, main
+
+
+def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
+    recorded: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "run-me.py"
+    target.write_text("print('hello')\n")
+
+    result = CliRunner().invoke(main, ["exec", str(target), "--flag", "value", "-x"])
+
+    assert result.exit_code == 0, result.output
+    assert recorded["command"] == [str(target), "--flag", "value", "-x"]
+    assert recorded["kwargs"] == {"check": False}
+
+
+def test_exec_propagates_child_exit_code(monkeypatch, tmp_path: Path):
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 17)
+
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    target = tmp_path / "run-me.py"
+    target.write_text("print('hello')\n")
+
+    result = CliRunner().invoke(main, ["exec", str(target)])
+
+    assert result.exit_code == 17
+
+
+def test_exec_classifies_local_script_vs_opaque_executable(tmp_path: Path):
+    script = tmp_path / "run-me.py"
+    script.write_text("print('hello')\n")
+
+    executable = tmp_path / "run-me"
+    executable.write_text("#!/bin/sh\necho hello\n")
+    executable.chmod(executable.stat().st_mode | 0o111)
+
+    assert classify_exec_target(str(script)) == "script"
+    assert classify_exec_target(str(executable)) == "executable"
+    assert classify_exec_target("python") == "executable"

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -4,6 +4,7 @@ import subprocess
 from types import SimpleNamespace
 from pathlib import Path
 
+import lamindb as ln
 import click
 import pytest
 from click.testing import CliRunner
@@ -14,6 +15,17 @@ from lamin_cli.__main__ import (
     parse_lamin_exec_uri,
     rewrite_exec_argv,
 )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def connected_instance(tmp_path_factory):
+    if ln.setup.settings._instance_exists:
+        yield
+        return
+
+    storage = tmp_path_factory.mktemp("lamin-cli-exec-storage")
+    ln.setup.init(storage=str(storage), name="lamin-cli-exec-tests")
+    yield
 
 
 def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
@@ -130,6 +142,9 @@ def test_exec_rewrites_lamin_uri_before_launch(monkeypatch, tmp_path: Path):
     monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
 
     target = "lamin://laminlabs/demo/artifact/1234567890abcdef/path/to/script.py"
+    rewritten_target = cache_path / "path/to/script.py"
+    rewritten_target.parent.mkdir(parents=True, exist_ok=True)
+    rewritten_target.write_text("print('cached script')\n")
 
     result = CliRunner().invoke(main, ["exec", target, "--input", target])
 

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -1,26 +1,25 @@
 from __future__ import annotations
 
 import subprocess
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
+import click
 import lamindb as ln
 import lamindb_setup as ln_setup
-import click
 import pytest
 from click.testing import CliRunner
+from lamin_cli.__main__ import (
+    _probe_exec_version,
+    classify_exec_target,
+    main,
+    parse_lamin_exec_uri,
+    parse_mount_storage_mappings,
+    rewrite_exec_argv,
+)
 from lamindb_setup.core._settings_store import (
     current_instance_settings_file,
     instance_settings_file,
-)
-
-from lamin_cli.__main__ import (
-    classify_exec_target,
-    main,
-    _probe_exec_version,
-    parse_mount_storage_mappings,
-    parse_lamin_exec_uri,
-    rewrite_exec_argv,
 )
 
 
@@ -87,7 +86,9 @@ def test_exec_returns_clean_exit_code_for_missing_executable(monkeypatch):
     def fake_run(command, **kwargs):
         raise FileNotFoundError(command[0])
 
-    monkeypatch.setattr("lamin_cli.__main__._probe_exec_version", lambda executable: None)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._probe_exec_version", lambda executable: None
+    )
     monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
 
     _delete_exec_records("missing-command")
@@ -158,11 +159,15 @@ def test_parse_lamin_exec_uri_rejects_invalid_inputs(uri: str):
         parse_lamin_exec_uri(uri)
 
 
-def test_rewrite_exec_argv_replaces_lamin_uri_with_cached_path(monkeypatch, tmp_path: Path):
+def test_rewrite_exec_argv_replaces_lamin_uri_with_cached_path(
+    monkeypatch, tmp_path: Path
+):
     cache_path = tmp_path / "artifact-cache"
     artifact = SimpleNamespace(cache=lambda: cache_path)
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = [
         "lamin://laminlabs/demo/artifact/1234567890abcdef/path/to/data.csv",
@@ -196,7 +201,9 @@ def test_rewrite_exec_argv_prefers_mounted_storage_path_when_present(
         cache=lambda: cache_path,
     )
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
 
@@ -220,7 +227,9 @@ def test_rewrite_exec_argv_falls_back_to_cache_when_mount_path_missing(
         cache=lambda: cache_path,
     )
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
 
@@ -247,7 +256,9 @@ def test_rewrite_exec_argv_applies_optional_subpath_to_mounted_roots(
         cache=lambda: cache_path,
     )
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef/nested/input.csv"]
 
@@ -257,7 +268,9 @@ def test_rewrite_exec_argv_applies_optional_subpath_to_mounted_roots(
     ) == [str(mounted_path)]
 
 
-def test_rewrite_exec_argv_supports_repeated_mount_mappings(monkeypatch, tmp_path: Path):
+def test_rewrite_exec_argv_supports_repeated_mount_mappings(
+    monkeypatch, tmp_path: Path
+):
     first_storage_root = tmp_path / "storage-root-a"
     second_storage_root = tmp_path / "storage-root-b"
     artifact_path = second_storage_root / "dataset" / "input.csv"
@@ -274,7 +287,9 @@ def test_rewrite_exec_argv_supports_repeated_mount_mappings(monkeypatch, tmp_pat
         cache=lambda: cache_path,
     )
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
 
@@ -306,7 +321,9 @@ def test_rewrite_exec_argv_supports_s3_mount_storage_mappings(
         cache=lambda: cache_path,
     )
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
 
@@ -338,7 +355,9 @@ def test_rewrite_exec_argv_prefers_most_specific_mount_storage_mapping(
         cache=lambda: cache_path,
     )
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
 
     argv = ["lamin://laminlabs/demo/artifact/1234567890abcdef"]
 
@@ -375,7 +394,9 @@ def test_exec_mount_storage_option_rewrites_target_before_launch(
         recorded["kwargs"] = kwargs
         return subprocess.CompletedProcess(command, 0)
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
     monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
 
     result = CliRunner().invoke(
@@ -466,7 +487,9 @@ def test_exec_reads_mount_storage_mappings_from_machine_local_config(
         recorded["kwargs"] = kwargs
         return subprocess.CompletedProcess(command, 0)
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
     monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
 
     result = CliRunner().invoke(
@@ -514,7 +537,9 @@ def test_exec_mount_storage_option_overrides_machine_local_config(
         recorded["kwargs"] = kwargs
         return subprocess.CompletedProcess(command, 0)
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
     monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
 
     result = CliRunner().invoke(
@@ -582,7 +607,9 @@ def test_exec_reports_invalid_machine_local_mount_storage_config(tmp_path: Path)
     assert "lamin settings mount-storage set" in result.output
 
 
-@pytest.mark.parametrize("mapping", ["missing-separator", "=mount-root", "storage-root="])
+@pytest.mark.parametrize(
+    "mapping", ["missing-separator", "=mount-root", "storage-root="]
+)
 def test_parse_mount_storage_mappings_rejects_invalid_syntax(mapping: str):
     with pytest.raises(click.BadParameter):
         parse_mount_storage_mappings((mapping,))
@@ -599,7 +626,9 @@ def test_exec_rewrites_lamin_uri_before_launch(monkeypatch, tmp_path: Path):
         recorded["kwargs"] = kwargs
         return subprocess.CompletedProcess(command, 0)
 
-    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr(
+        "lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact
+    )
     monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
 
     target = "lamin://laminlabs/demo/artifact/1234567890abcdef/path/to/script.py"

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -5,9 +5,14 @@ from types import SimpleNamespace
 from pathlib import Path
 
 import lamindb as ln
+import lamindb_setup as ln_setup
 import click
 import pytest
 from click.testing import CliRunner
+from lamindb_setup.core._settings_store import (
+    current_instance_settings_file,
+    instance_settings_file,
+)
 
 from lamin_cli.__main__ import (
     classify_exec_target,
@@ -35,6 +40,18 @@ def _delete_exec_records(key: str) -> None:
         run.delete(permanent=True)
     for transform in ln.Transform.filter(key=key).all():
         transform.delete(permanent=True)
+
+
+def _mount_storage_config_path() -> Path:
+    return ln_setup.settings.settings_dir / "exec-mount-storage.txt"
+
+
+@pytest.fixture(autouse=True)
+def clear_mount_storage_config():
+    config_path = _mount_storage_config_path()
+    config_path.unlink(missing_ok=True)
+    yield
+    config_path.unlink(missing_ok=True)
 
 
 def test_exec_forwards_child_argv(monkeypatch, tmp_path: Path):
@@ -337,6 +354,165 @@ def test_exec_mount_storage_option_rewrites_target_before_launch(
     assert result.exit_code == 0, result.output
     assert recorded["command"] == [str(mounted_path)]
     assert recorded["kwargs"] == {"check": False}
+
+
+def test_settings_mount_storage_persists_one_or_more_machine_local_mappings(
+    tmp_path: Path,
+):
+    first_mapping = f"s3://bucket-a/prefix={tmp_path / 'mount-a'}"
+    second_mapping = f"s3://bucket-b/prefix={tmp_path / 'mount-b'}"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        ["settings", "mount-storage", "set", first_mapping, second_mapping],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _mount_storage_config_path().exists()
+    assert _mount_storage_config_path().read_text().splitlines() == [
+        first_mapping,
+        second_mapping,
+    ]
+
+    get_result = runner.invoke(main, ["settings", "mount-storage", "get"])
+
+    assert get_result.exit_code == 0, get_result.output
+    assert get_result.output.strip().splitlines() == [first_mapping, second_mapping]
+
+
+def test_settings_mount_storage_get_returns_none_when_unset():
+    result = CliRunner().invoke(main, ["settings", "mount-storage", "get"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "None"
+
+
+def test_settings_mount_storage_unset_removes_machine_local_config(tmp_path: Path):
+    mapping = f"s3://bucket/prefix={tmp_path / 'mount-root'}"
+    runner = CliRunner()
+
+    set_result = runner.invoke(main, ["settings", "mount-storage", "set", mapping])
+
+    assert set_result.exit_code == 0, set_result.output
+    assert _mount_storage_config_path().exists()
+
+    unset_result = runner.invoke(main, ["settings", "mount-storage", "unset"])
+
+    assert unset_result.exit_code == 0, unset_result.output
+    assert not _mount_storage_config_path().exists()
+
+
+def test_exec_reads_mount_storage_mappings_from_machine_local_config(
+    monkeypatch, tmp_path: Path
+):
+    recorded: dict[str, object] = {}
+    storage_root = "s3://bucket/prefix"
+    mount_root = tmp_path / "mount-root"
+    mounted_path = mount_root / "dataset" / "script.py"
+    mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    mounted_path.write_text("print('mounted script')\n")
+    artifact = SimpleNamespace(
+        path=f"{storage_root}/dataset/script.py",
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: tmp_path / "artifact-cache",
+    )
+
+    set_result = CliRunner().invoke(
+        main,
+        ["settings", "mount-storage", "set", f"{storage_root}={mount_root}"],
+    )
+    assert set_result.exit_code == 0, set_result.output
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "lamin://laminlabs/demo/artifact/1234567890abcdef"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded["command"] == [str(mounted_path)]
+    assert recorded["kwargs"] == {"check": False}
+
+
+def test_exec_mount_storage_option_overrides_machine_local_config(
+    monkeypatch, tmp_path: Path
+):
+    recorded: dict[str, object] = {}
+    storage_root = "s3://bucket/prefix"
+    configured_mount_root = tmp_path / "configured-mount-root"
+    configured_mounted_path = configured_mount_root / "dataset" / "script.py"
+    configured_mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    configured_mounted_path.write_text("print('configured')\n")
+    cli_mount_root = tmp_path / "cli-mount-root"
+    cli_mounted_path = cli_mount_root / "dataset" / "script.py"
+    cli_mounted_path.parent.mkdir(parents=True, exist_ok=True)
+    cli_mounted_path.write_text("print('cli')\n")
+    artifact = SimpleNamespace(
+        path=f"{storage_root}/dataset/script.py",
+        storage=SimpleNamespace(root=storage_root),
+        cache=lambda: tmp_path / "artifact-cache",
+    )
+
+    set_result = CliRunner().invoke(
+        main,
+        [
+            "settings",
+            "mount-storage",
+            "set",
+            f"{storage_root}={configured_mount_root}",
+        ],
+    )
+    assert set_result.exit_code == 0, set_result.output
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("lamin_cli.__main__._load_exec_artifact", lambda instance, uid: artifact)
+    monkeypatch.setattr("lamin_cli.__main__.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--mount-storage",
+            f"{storage_root}={cli_mount_root}",
+            "lamin://laminlabs/demo/artifact/1234567890abcdef",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded["command"] == [str(cli_mounted_path)]
+    assert recorded["kwargs"] == {"check": False}
+
+
+def test_settings_mount_storage_stays_machine_local(tmp_path: Path):
+    first_mapping = f"s3://bucket-a/prefix={tmp_path / 'mount-a'}"
+    current_instance_before = current_instance_settings_file().read_text()
+    instance_settings_path = instance_settings_file(
+        ln_setup.settings.instance.name,
+        ln_setup.settings.instance.owner,
+    )
+    instance_settings_before = instance_settings_path.read_text()
+
+    result = CliRunner().invoke(
+        main,
+        ["settings", "mount-storage", "set", first_mapping],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _mount_storage_config_path().parent == ln_setup.settings.settings_dir
+    assert current_instance_settings_file().read_text() == current_instance_before
+    assert instance_settings_path.read_text() == instance_settings_before
 
 
 @pytest.mark.parametrize("mapping", ["missing-separator", "=mount-root", "storage-root="])


### PR DESCRIPTION
## Summary

This change adds tracked shell execution via `lamin exec.

The updated CLI flow can:
- execute a script or existing executable through `lamin exec`
- create and track a `Transform` and `Run` for the invocation
- capture the exact CLI parameters used for execution
- resolve `lamin://<owner>/<instance>/artifact/<uid>[/<subpath>]` inputs to local paths
- discover and register outputs produced by the executed process
- prefer locally mounted storage paths over cache fallback for S3-backed storage when mount mappings are configured

This PR also adds machine-local `mount-storage` settings support.

## Changes

- Added `lamin exec` support in the CLI via the updated `lamin-cli` submodule
- Added artifact URI parsing and local path rewriting for `lamin://...` inputs
- Added transform/run tracking for script and executable invocations
- Added output collection and artifact registration for explicit and inferred outputs
- Added machine-local `mount-storage` config handling for mounted-storage-first resolution

## Validation

- `cd sub/lamin-cli && uv run pytest tests/test_exec.py`

## Commits

- **feat: Add initial lamin exec command**
- **feat: Resolve lamin exec artifact URIs**
- **feat: Track lamin exec lineage**
- **feat: Register lamin exec outputs**
- **feat: Add lamin exec mount resolution**
- **feat: Persist lamin exec mount mappings**
- **feat: Harden lamin exec mount mappings**
- **lint, precommit, ..**
