### PR TITLE
🐛 Fix `lamin create branch` hub path

### DIFF
--- a/lamin_cli/hub/branches.py
+++ b/lamin_cli/hub/branches.py
@@ -25,15 +25,12 @@ def list_branches(limit: int = 100) -> pd.DataFrame:
 
 def create_branch(name: str, description: str | None = None) -> dict[str, Any]:
     data = request_json(
-        "post",
-        path="branches",
-        body={"branch_name": name, "description": description},
+        "put",
+        path=module_model_path("core", "branch"),
+        body={"name": name, "description": description},
     )
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        return data[0]
     if isinstance(data, dict):
-        body = data.get("body")
-        if isinstance(body, dict):
-            branch = body.get("branch")
-            if isinstance(branch, dict):
-                return branch
         return data
     return {"name": name}

--- a/tests/hub/test_branches.py
+++ b/tests/hub/test_branches.py
@@ -46,13 +46,7 @@ def test_create_branch_constructs_request(monkeypatch):
 
     def fake_request_json(method, path, *, params=None, body=None):
         calls.append((method, path, params, body))
-        return {
-            "statusCode": 200,
-            "body": {
-                "message": "Branch created successfully",
-                "branch": {"name": "new"},
-            },
-        }
+        return [{"id": 1, "uid": "abc123", "name": "new", "description": None}]
 
     monkeypatch.setattr("lamin_cli.hub.branches.request_json", fake_request_json)
 
@@ -60,10 +54,10 @@ def test_create_branch_constructs_request(monkeypatch):
 
     assert calls == [
         (
-            "post",
-            "branches",
+            "put",
+            "modules/core/branch",
             None,
-            {"branch_name": "new", "description": None},
+            {"name": "new", "description": None},
         )
     ]
-    assert result == {"name": "new"}
+    assert result == {"id": 1, "uid": "abc123", "name": "new", "description": None}


### PR DESCRIPTION
This was accidentally routed to a temporary test endpoint rather than the canonical REST API.