### PR TITLE
⚡️ Speed up `lamin switch` by a factor 2-3

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -407,28 +407,35 @@ def switch(
 
     → Python/R alternative: {attr}`~lamindb.setup.core.SetupSettings.branch` and {attr}`~lamindb.setup.core.SetupSettings.space`
     """
-    from lamindb.errors import BranchAlreadyExists, ObjectDoesNotExist
-    from lamindb.setup import switch as switch_
+    def _switch_target(target_name: str | None, *, switch_space: bool) -> None:
+        if not switch_space and ln_setup.settings.instance.is_managed_by_hub:
+            from lamin_cli.hub import switch_branch
+
+            switch_branch(target_name, create=create)
+            return
+
+        from lamindb.errors import BranchAlreadyExists, ObjectDoesNotExist
+        from lamindb.setup import switch as switch_
+
+        try:
+            switch_(target_name, space=switch_space, create=create)
+        except (ObjectDoesNotExist, BranchAlreadyExists) as e:
+            raise click.ClickException(str(e)) from e
+
     # Backward compatibility: lamin switch branch X / lamin switch space Y (deprecated, hidden from help)
     if len(target) == 2 and target[0] in ("branch", "space"):
         kind, name = target[0], target[1]
         logger.warn(
             f"'lamin switch {kind} <name>' is deprecated and will be removed in a future version. "
             f"Use 'lamin switch {name}' for branches or 'lamin switch --space {name}' for spaces instead.",        )
-        try:
-            switch_(name, space=(kind == "space"), create=create)
-        except (ObjectDoesNotExist, BranchAlreadyExists) as e:
-            raise click.ClickException(str(e)) from e
+        _switch_target(name, switch_space=(kind == "space"))
         return
 
     # Normal usage: single target (or none)
     if len(target) > 1:
         raise click.ClickException("Too many arguments. Use 'lamin switch <target>' or 'lamin switch --space <space>'.")
     target_str = target[0] if len(target) == 1 else None
-    try:
-        switch_(target_str, space=space, create=create)
-    except (ObjectDoesNotExist, BranchAlreadyExists) as e:
-        raise click.ClickException(str(e)) from e
+    _switch_target(target_str, switch_space=space)
 
 
 # fmt: off

--- a/lamin_cli/hub/__init__.py
+++ b/lamin_cli/hub/__init__.py
@@ -7,6 +7,7 @@ from ._query import get_record, list_records
 from ._schema import schema
 from ._statistics import relation_counts, statistics
 from .branches import create_branch, list_branches
+from .switch import switch_branch
 
 
 @hub_group
@@ -34,4 +35,5 @@ __all__ = [
     "module_model_path",
     "list_branches",
     "create_branch",
+    "switch_branch",
 ]

--- a/lamin_cli/hub/switch.py
+++ b/lamin_cli/hub/switch.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+import lamindb_setup as ln_setup
+from lamin_utils import logger
+from lamindb_setup.core._settings_store import settings_dir
+
+from ._click import click
+from ._client import module_model_path, request_json
+from .branches import create_branch
+
+
+def _normalize_branch_payload(data: Any) -> dict[str, Any] | None:
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                return item
+    return None
+
+
+def _extract_uid_name(payload: dict[str, Any] | None) -> tuple[str | None, str | None]:
+    if payload is None:
+        return None, None
+    uid = payload.get("uid")
+    name = payload.get("name")
+    return (
+        str(uid) if uid is not None and str(uid).strip() else None,
+        str(name) if name is not None and str(name).strip() else None,
+    )
+
+
+def _get_branch(target: str) -> dict[str, Any] | None:
+    data = request_json(
+        "post",
+        path=module_model_path("core", "branch"),
+        params={"limit": 1, "offset": 0},
+        body={
+            "select": ["uid", "name"],
+            "filter": {
+                "or": [
+                    {"name": {"eq": target}},
+                    {"uid": {"eq": target}},
+                ]
+            },
+        },
+    )
+    return _normalize_branch_payload(data)
+
+
+def _branch_settings_path():
+    instance = ln_setup.settings.instance
+    return settings_dir / f"current-branch--{instance.owner}--{instance.name}.txt"
+
+
+def _write_current_branch(uid: str, name: str) -> None:
+    _branch_settings_path().write_text(f"{uid}\n{name}")
+    # Clear cache so current process reloads branch from file on next access.
+    ln_setup.settings._branch = None
+
+
+def switch_branch(target: str | None, *, create: bool = False) -> None:
+    if target is None:
+        raise click.ClickException(
+            "Please pass a branch name or uid. Example: lamin switch main"
+        )
+    if create:
+        created_branch = create_branch(target)
+        uid, name = _extract_uid_name(created_branch)
+        if uid is None or name is None:
+            resolved_branch = _get_branch(target)
+            uid, name = _extract_uid_name(resolved_branch)
+        if uid is None or name is None:
+            raise click.ClickException(
+                f"Created branch '{target}' but could not resolve uid/name from hub response."
+            )
+        logger.important(f"created branch: {name}")
+    else:
+        resolved_branch = _get_branch(target)
+        uid, name = _extract_uid_name(resolved_branch)
+        if uid is None or name is None:
+            raise click.ClickException(
+                f"Branch '{target}', please check on the hub UI whether you have the correct `uid` or `name`."
+            )
+
+    _write_current_branch(uid, name)
+    logger.important(f"switched to {target}")

--- a/tests/core/test_create_switch_delete_list_settings_merge.py
+++ b/tests/core/test_create_switch_delete_list_settings_merge.py
@@ -12,6 +12,7 @@ from lamin_cli.__main__ import main
 from lamindb_setup.core._settings_store import (
     current_modules_file,
     local_current_instance_file,
+    settings_dir,
 )
 from lamindb_setup.errors import CurrentInstanceNotConfigured, NoWriteAccess
 
@@ -158,6 +159,86 @@ def test_list_branch_managed_uses_hub(monkeypatch):
     assert result.exit_code == 0
     assert calls["list"] == [5]
     assert "managed-branch-list" in result.output
+
+
+def test_switch_branch_managed_uses_hub(monkeypatch):
+    calls = []
+
+    def fake_switch_branch(target, create=False):
+        calls.append((target, create))
+
+    def should_not_be_called(*args, **kwargs):
+        raise AssertionError(
+            "lamindb.setup.switch should not be called for managed branch switch"
+        )
+
+    monkeypatch.setattr("lamin_cli.hub.switch_branch", fake_switch_branch)
+    monkeypatch.setattr("lamindb.setup.switch", should_not_be_called)
+    instance = ln_setup.settings.instance
+    original_api_url = instance._api_url
+    instance._api_url = "https://lamin.ai/api"
+    try:
+        result = CliRunner().invoke(main, ["switch", "managedbranch"])
+    finally:
+        instance._api_url = original_api_url
+
+    assert result.exit_code == 0
+    assert calls == [("managedbranch", False)]
+
+
+def test_hub_switch_branch_writes_branch_file(monkeypatch):
+    from lamin_cli.hub.switch import switch_branch
+
+    instance = ln_setup.settings.instance
+    branch_file = (
+        settings_dir / f"current-branch--{instance.owner}--{instance.name}.txt"
+    )
+    original_contents = branch_file.read_text() if branch_file.exists() else None
+
+    def fake_request_json(method, path, *, params=None, body=None):
+        return {"uid": "z9x8c7v6b5n4m3k2", "name": "managedbranch"}
+
+    monkeypatch.setattr("lamin_cli.hub.switch.request_json", fake_request_json)
+    try:
+        switch_branch("managedbranch")
+        assert branch_file.read_text() == "z9x8c7v6b5n4m3k2\nmanagedbranch"
+    finally:
+        if original_contents is None:
+            branch_file.unlink(missing_ok=True)
+        else:
+            branch_file.write_text(original_contents)
+
+
+def test_hub_switch_branch_create_existing_raises(monkeypatch):
+    from lamin_cli.hub._click import click as hub_click
+    from lamin_cli.hub.switch import switch_branch
+
+    def fake_create_branch(name, description=None):
+        raise hub_click.ClickException(
+            f"Branch '{name}' already exists. Omit -c/--create to switch to it."
+        )
+
+    monkeypatch.setattr("lamin_cli.hub.switch.create_branch", fake_create_branch)
+
+    with pytest.raises(hub_click.ClickException, match="already exists"):
+        switch_branch("existingbranch", create=True)
+
+
+def test_hub_switch_branch_missing_branch_raises(monkeypatch):
+    from lamin_cli.hub._click import click as hub_click
+    from lamin_cli.hub.switch import switch_branch
+
+    def fake_request_json(method, path, *, params=None, body=None):
+        if path.endswith("/missingbranch"):
+            return None
+        if path.endswith("/branch"):
+            return []
+        return None
+
+    monkeypatch.setattr("lamin_cli.hub.switch.request_json", fake_request_json)
+
+    with pytest.raises(hub_click.ClickException, match="please check on the hub UI"):
+        switch_branch("missingbranch")
 
 
 def test_merge():

--- a/tests/profiling/lamin_switch_and_create_branch.py
+++ b/tests/profiling/lamin_switch_and_create_branch.py
@@ -1,7 +1,7 @@
 def main():
-    from lamindb.setup import switch
+    from lamin_cli.hub import switch_branch
 
-    switch("test-branch-profiling", create=True)
+    switch_branch("test-branch-profiling", create=True)
 
 
 def cleanup():


### PR DESCRIPTION
Without `-c/--create`:

Before | After
--- | ---
<img width="526" height="66" alt="image" src="https://github.com/user-attachments/assets/4f9e5d68-bbb8-4dc8-9fb3-4f5e44d78b87" /> | <img width="511" height="49" alt="image" src="https://github.com/user-attachments/assets/0cd73d54-b786-416d-8836-4cc8b63054d9" />

With `-c/--create`:

Before | After
--- | ---
<img width="598" height="79" alt="image" src="https://github.com/user-attachments/assets/381e8090-3209-49fc-8d05-423655e540f4" /> | <img width="593" height="65" alt="image" src="https://github.com/user-attachments/assets/da4fea2b-16df-45bb-9f19-374f055d14ca" />

Registry: https://lamin.ai/laminlabs/lamindata/record/hxiYuZ7EH3L7SzyJ

Commit: `b26320c6ee99abd1`

<img width="1477" alt="image" src="https://github.com/user-attachments/assets/eba763df-78c3-4aa0-ad0c-07e7fd33e653" />

Similar to:

- https://github.com/laminlabs/lamin-cli/pull/228
- https://github.com/laminlabs/lamin-cli/pull/227