### PR TITLE
🚸 Support parallel sessions in Claude Code

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -1029,8 +1029,8 @@ def track_finish_command() -> None:
 
     This can be a shell script run or a Claude Code session.
     """
-    claude_run_uid_file = Path(".claude/.lamindb_run_uid")
-    if claude_run_uid_file.exists():
+    from lamin_cli.agents.claude import _run_uid_file
+    if _run_uid_file().exists():
         from lamin_cli.agents.claude import finish_claudecode_session
         return finish_claudecode_session()
     from lamin_cli._context import finish as finish_

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -13,8 +13,6 @@ import click
 # --- constants ---
 
 _CLAUDE_DIR = Path(".claude")
-_RUN_UID_FILE = _CLAUDE_DIR / ".lamindb_run_uid"
-_TRANSCRIPT_PATH_FILE = _CLAUDE_DIR / ".lamindb_transcript_path"
 _TRANSFORM_KEY = "__claudecode__"
 _TRANSFORM_UID = "SnfuhjObaAKR0000"
 _SKILL_MARKER = "Base directory for this skill:"
@@ -67,6 +65,18 @@ def _warn(msg: str) -> None:
 # --- lamindb helpers ---
 
 
+def _session_id() -> str:
+    return os.environ.get("CLAUDE_CODE_SESSION_ID", "default")
+
+
+def _run_uid_file() -> Path:
+    return _CLAUDE_DIR / f".lamindb_run_uid_{_session_id()}"
+
+
+def _transcript_path_file() -> Path:
+    return _CLAUDE_DIR / f".lamindb_transcript_path_{_session_id()}"
+
+
 def _get_transcript_path() -> Path:
     session_id = os.environ.get("CLAUDE_CODE_SESSION_ID", "")
     projects_dir = Path.home() / ".claude" / "projects"
@@ -117,8 +127,8 @@ def track_claudecode_session(name: str | None = None) -> None:
         run = ln.Run(transform, status="started", name=name).save()
 
         _CLAUDE_DIR.mkdir(exist_ok=True)
-        _RUN_UID_FILE.write_text(run.uid)
-        _TRANSCRIPT_PATH_FILE.write_text(str(_get_transcript_path()))
+        _run_uid_file().write_text(run.uid)
+        _transcript_path_file().write_text(str(_get_transcript_path()))
         _info(f"started tracking Claude Code session: {run.uid}")
     except Exception as e:
         _warn(f"lamindb session tracking failed, continuing without tracking: {e}")
@@ -324,13 +334,14 @@ def finish_claudecode_session() -> None:
             _warn("no lamindb instance connected, skipping session finish")
             return
 
-        if not _RUN_UID_FILE.exists():
+        run_uid_file = _run_uid_file()
+        if not run_uid_file.exists():
             _warn("no active Claude Code session found, skipping session finish")
             return
 
-        uid = _RUN_UID_FILE.read_text().strip()
+        uid = run_uid_file.read_text().strip()
         run = ln.Run.get(uid=uid)
-        transcript_path = Path(_TRANSCRIPT_PATH_FILE.read_text().strip())
+        transcript_path = Path(_transcript_path_file().read_text().strip())
 
         # The path stored at session start can be stale if it was derived from a
         # cwd that differs from Claude Code's launch dir; re-resolve as a fallback.
@@ -345,8 +356,8 @@ def finish_claudecode_session() -> None:
             run._status_code = 0  # completed
             run.finished_at = datetime.now(timezone.utc)
             run.save()
-            _RUN_UID_FILE.unlink()
-            _TRANSCRIPT_PATH_FILE.unlink()
+            run_uid_file.unlink()
+            _transcript_path_file().unlink()
             return
 
         entries = _parse_transcript(transcript_path)
@@ -372,8 +383,8 @@ def finish_claudecode_session() -> None:
         run.finished_at = datetime.now(timezone.utc)
         run.save()
 
-        _RUN_UID_FILE.unlink()
-        _TRANSCRIPT_PATH_FILE.unlink()
+        run_uid_file.unlink()
+        _transcript_path_file().unlink()
         _info(f"finished tracking Claude Code session: {run.uid}")
     except Exception as e:
         _warn(f"lamindb session finish failed, continuing: {e}")

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -95,7 +95,10 @@ def _get_transcript_path() -> Path:
 
 
 def _instance_connected(ln: object) -> bool:
-    return bool(ln.setup.settings.is_configured)  # type: ignore[attr-defined]
+    s = ln.setup.settings  # type: ignore[attr-defined]
+    if hasattr(s, "is_configured"):
+        return bool(s.is_configured)
+    return bool(s._instance_exists)
 
 
 # --- session start ---

--- a/tests/agents/test_track_claude.py
+++ b/tests/agents/test_track_claude.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import lamindb as ln
 import pytest
 from lamin_cli.agents.claude import (
-    _RUN_UID_FILE,
-    _TRANSCRIPT_PATH_FILE,
     _TRANSFORM_KEY,
+    _run_uid_file,
+    _transcript_path_file,
     finish_claudecode_session,
     track_claudecode_session,
 )
@@ -16,6 +16,7 @@ from lamin_cli.agents.claude import (
 @pytest.fixture(autouse=True)
 def isolated(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "test-session")
     yield
     t = ln.Transform.filter(key=_TRANSFORM_KEY).first()
     if t is not None:
@@ -45,8 +46,8 @@ def test_full_track_finish_flow(tmp_path):
     # track opens a run and writes state files
     track_claudecode_session(name="integration test")
 
-    assert _RUN_UID_FILE.exists()
-    uid = _RUN_UID_FILE.read_text().strip()
+    assert _run_uid_file().exists()
+    uid = _run_uid_file().read_text().strip()
     session_run = ln.Run.get(uid=uid)
     assert session_run.finished_at is None
 
@@ -58,10 +59,10 @@ def test_full_track_finish_flow(tmp_path):
 
     # finish closes the run, saves report, and stamps child transform
     transcript = _write_transcript(tmp_path)
-    _TRANSCRIPT_PATH_FILE.write_text(str(transcript))
+    _transcript_path_file().write_text(str(transcript))
     finish_claudecode_session()
 
-    assert not _RUN_UID_FILE.exists()
+    assert not _run_uid_file().exists()
     session_run = ln.Run.get(uid=uid)
     assert session_run.finished_at is not None
     assert session_run.report is not None
@@ -74,6 +75,20 @@ def test_full_track_finish_flow(tmp_path):
     # Cleanup
     child_run.delete(permanent=True)
     child_transform.delete(permanent=True)
+
+
+def test_parallel_sessions_use_separate_state_files(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-a")
+    track_claudecode_session(name="session a")
+    uid_a = _run_uid_file().read_text().strip()
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "session-b")
+    track_claudecode_session(name="session b")
+    uid_b = _run_uid_file().read_text().strip()
+
+    assert uid_a != uid_b
+    assert Path(".claude/.lamindb_run_uid_session-a").exists()
+    assert Path(".claude/.lamindb_run_uid_session-b").exists()
 
 
 def test_track_reuses_transform_across_sessions():


### PR DESCRIPTION
- Support parallel Claude Code sessions by making state files session-specific (.lamindb_run_uid_<session_id>) so concurrent sessions no longer overwrite each other
- Update track finish dispatch and tests to use CLAUDE_CODE_SESSION_ID for session isolation