### PR TITLE
📝 Update `lamin track` help to reference lamindb skill

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -990,7 +990,7 @@ def track(ctx: click.Context):
     sh my_script.sh
     ```
 
-    Ask **Claude Code** to track its session based on the `lamindb` skill, see [here](https://github.com/laminlabs/lamin-skills/blob/main/skills/lamindb/references/track_claude.md). It will call:
+    The `lamindb` [skill](https://github.com/laminlabs/lamin-skills/tree/main/skills/lamindb) ships with the `lamindb` package at `.agents/skills/lamindb/`. Copy it to `.claude/skills/` to have Claude Code automatically track its sessions. It will call:
 
     ```
     lamin track claude

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -990,7 +990,7 @@ def track(ctx: click.Context):
     sh my_script.sh
     ```
 
-    The `lamindb` [skill](https://github.com/laminlabs/lamin-skills/tree/main/skills/lamindb) ships with the `lamindb` package at `.agents/skills/lamindb/`. Copy it to `.claude/skills/` to have Claude Code automatically track its sessions. It will call:
+    The `lamindb` [skill](https://github.com/laminlabs/lamin-skills/tree/main/skills/lamindb) ships with the `lamindb` package at `.agents/skills/lamindb/`. When working with Claude Code, ask it to copy the skill to `.claude/skills/` so that it automatically tracks transcripts. It will call:
 
     ```
     lamin track claude


### PR DESCRIPTION
Update `lamin track` help text to reference the `lamindb` skill bundled with the package. See also laminlabs/lamindb#3805 for the other occurrences.