### PR TITLE
✨ Add Copilot session tracking (lamin track copilot)

### DIFF
--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -990,11 +990,11 @@ def track(ctx: click.Context):
     sh my_script.sh
     ```
 
-    The `lamindb` [skill](https://github.com/laminlabs/lamin-skills) ships with the `lamindb` package at `.agents/skills/`. When working with Claude Code, ask it to copy the skill to `.claude/skills/` so that it automatically tracks agent sessions. It will call:
+    The `lamindb` [skill](https://github.com/laminlabs/lamin-skills) ships with the `lamindb` package at `.agents/skills/`. When working with Claude Code or GitHub Copilot, ask it to copy the skill to `.claude/skills/` so that it automatically tracks agent sessions. It will call:
 
     ```
-    lamin track claude
-    # work with Claude Code
+    lamin track claude   # or: lamin track copilot
+    # work with the agent
     lamin track finish
     ```
 
@@ -1023,16 +1023,39 @@ def track_claude_command(name: str | None) -> None:
     return track_claudecode_session(name=name)
 
 
+@track.command("copilot")
+@click.option(
+    "--name",
+    type=str,
+    default=None,
+    help="One-sentence name for this agent session.",
+)
+def track_copilot_command(name: str | None) -> None:
+    """Start tracking a GitHub Copilot session in LaminDB.
+
+    Creates a new Copilot run. Writes the run UID to `.claude/` so that
+    `lamin track finish` can close it.
+    """
+    from lamin_cli.agents.copilot import track_copilot_session
+    return track_copilot_session(name=name)
+
+
 @track.command("finish")
 def track_finish_command() -> None:
     """Finish a tracked session.
 
-    This can be a shell script run or a Claude Code session.
+    This can be a shell script run, a Claude Code session, or a Copilot session.
     """
-    from lamin_cli.agents.claude import _run_uid_file
-    if _run_uid_file().exists():
+    from lamin_cli.agents.claude import _run_uid_file as _claude_run_uid_file
+    if _claude_run_uid_file().exists():
         from lamin_cli.agents.claude import finish_claudecode_session
         return finish_claudecode_session()
+
+    from lamin_cli.agents.copilot import _STATE_DIR as _copilot_state_dir
+    if list(_copilot_state_dir.glob(".lamindb_run_uid_copilot_*")):
+        from lamin_cli.agents.copilot import finish_copilot_session
+        return finish_copilot_session()
+
     from lamin_cli._context import finish as finish_
     return finish_()
 

--- a/lamin_cli/__main__.py
+++ b/lamin_cli/__main__.py
@@ -1051,8 +1051,8 @@ def track_finish_command() -> None:
         from lamin_cli.agents.claude import finish_claudecode_session
         return finish_claudecode_session()
 
-    from lamin_cli.agents.copilot import _STATE_DIR as _copilot_state_dir
-    if list(_copilot_state_dir.glob(".lamindb_run_uid_copilot_*")):
+    from lamin_cli.agents.copilot import _state_dir as _copilot_state_dir
+    if list(_copilot_state_dir().glob(".lamindb_run_uid_copilot_*")):
         from lamin_cli.agents.copilot import finish_copilot_session
         return finish_copilot_session()
 

--- a/lamin_cli/agents/_common.py
+++ b/lamin_cli/agents/_common.py
@@ -331,11 +331,14 @@ def stamp_transforms(
     script_path_keys: tuple[str, ...] = (),
     suffix_to_kind: dict[str, str] | None = None,
 ) -> None:
+    from pathlib import Path
+
     # Primary path: scripts run with LAMIN_INITIATED_BY_RUN_UID create child runs.
     already_stamped: set[str] = set()
     for child_run in run.initiated_runs.all():  # type: ignore[attr-defined]
         t = child_run.transform
-        already_stamped.add(t.key)
+        if t.key:
+            already_stamped.add(Path(t.key).name)
         if t.run_id is None:
             t.run = run
             t.save()

--- a/lamin_cli/agents/_common.py
+++ b/lamin_cli/agents/_common.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import html
+import re
+from typing import Callable
+
+import click
+
+# --- constants ---
+
+BLOCK_TRUNCATE = 4000
+
+HTML_TEMPLATE = """\
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Session Transcript</title>
+<style>
+*{{box-sizing:border-box;margin:0;padding:0}}
+body{{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111;max-width:800px;margin:0 auto;padding:1.5rem;font-size:14px;line-height:1.5}}
+ul{{list-style:none}}
+li.step{{display:flex;align-items:flex-start;gap:10px;padding:3px 0}}
+.dot{{width:8px;height:8px;border-radius:50%;flex-shrink:0;margin-top:6px}}
+.dg{{background:#23d18b}}.dy{{background:#bbb}}.db{{background:#2472c8}}
+.bd{{flex:1;min-width:0}}
+.tt{{font-weight:600;color:#111}}
+.lb{{font-weight:400;color:#888;font-size:.85em;margin-left:6px}}
+.tx{{white-space:pre-wrap;word-wrap:break-word;color:#333;margin-top:2px}}
+.user-msg{{background:#eef4fd;border-radius:6px;padding:8px 10px;margin:2px 0}}
+.user-msg .tt{{color:#2472c8;font-size:.8rem;text-transform:uppercase;letter-spacing:.04em;margin-bottom:2px}}
+.io{{margin-top:6px;border-radius:4px;border:1px solid #e5e5e5;overflow:hidden;font-family:ui-monospace,monospace;font-size:.82rem}}
+.iotag{{padding:2px 8px;background:#f5f5f5;color:#888;font-size:.72rem;font-weight:700;letter-spacing:.08em}}
+.iopre{{padding:6px 10px;background:#fafafa;white-space:pre-wrap;word-wrap:break-word;color:#333}}
+details summary{{cursor:pointer;color:#888;font-size:.85rem;list-style:none}}
+details summary::-webkit-details-marker{{display:none}}
+details summary::before{{content:'▶ ';font-size:.7em}}
+details[open] summary::before{{content:'▼ '}}
+.thk{{margin-top:4px;color:#666;font-size:.85rem;white-space:pre-wrap;word-wrap:break-word;padding-left:8px;border-left:2px solid #e5e5e5}}
+.todos{{margin-top:4px}}
+.todo{{display:flex;gap:6px;color:#333;font-size:.88rem;padding:1px 0}}
+.done{{color:#aaa;text-decoration:line-through}}
+</style></head>
+<body><ul>
+{steps}
+</ul></body></html>"""
+
+_ANSI_SGR = re.compile(r"\x1b\[([0-9;]*)m")
+_ANSI_BASE_COLORS = ["#000", "#cd3131", "#0dbc79", "#e5e510", "#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5"]
+_ANSI_BRIGHT_COLORS = ["#666", "#f14c4c", "#23d18b", "#f5f543", "#3b8eea", "#d670d6", "#29b8db", "#fff"]
+
+
+def ansi_to_html(text: str) -> str:
+    """Convert ANSI SGR color codes to HTML spans; HTML-escape all other text."""
+    result: list[str] = []
+    style: dict[str, str] = {}
+    span_open = False
+    cursor = 0
+
+    def css(s: dict[str, str]) -> str:
+        parts = []
+        if "fg" in s:
+            parts.append(f"color:{s['fg']}")
+        if "bg" in s:
+            parts.append(f"background:{s['bg']}")
+        if s.get("bold"):
+            parts.append("font-weight:700")
+        return ";".join(parts)
+
+    for m in _ANSI_SGR.finditer(text):
+        result.append(html.escape(text[cursor:m.start()]))
+        cursor = m.end()
+        codes = [int(c) for c in m.group(1).split(";") if c] if m.group(1) else [0]
+        i = 0
+        while i < len(codes):
+            c = codes[i]
+            if c == 0:
+                style = {}
+            elif c == 1:
+                style["bold"] = "1"
+            elif 30 <= c <= 37:
+                style["fg"] = _ANSI_BASE_COLORS[c - 30]
+            elif 90 <= c <= 97:
+                style["fg"] = _ANSI_BRIGHT_COLORS[c - 90]
+            elif 40 <= c <= 47:
+                style["bg"] = _ANSI_BASE_COLORS[c - 40]
+            elif c == 39:
+                style.pop("fg", None)
+            elif c == 49:
+                style.pop("bg", None)
+            i += 1
+        new_css = css(style)
+        if span_open:
+            result.append("</span>")
+            span_open = False
+        if new_css:
+            result.append(f'<span style="{new_css}">')
+            span_open = True
+
+    result.append(html.escape(text[cursor:]))
+    if span_open:
+        result.append("</span>")
+    return "".join(result)
+
+
+# --- output helpers ---
+
+
+def info(msg: str) -> None:
+    click.echo(f"✓ {msg}")
+
+
+def warn(msg: str) -> None:
+    click.echo(f"! {msg}", err=True)
+
+
+# --- lamindb helpers ---
+
+
+def instance_connected(ln: object) -> bool:
+    s = ln.setup.settings  # type: ignore[attr-defined]
+    if hasattr(s, "is_configured"):
+        return bool(s.is_configured)
+    return bool(s._instance_exists)
+
+
+# --- HTML rendering ---
+# Shared across agents. Agent-specific quirks (which tool name means "shell",
+# which commands are this agent's own bookkeeping) are passed in as arguments
+# rather than hardcoded, so the same renderer works for Claude, Copilot, etc.
+
+
+def render_thinking(thinking: str) -> str:
+    return (
+        '<li class="step"><div class="dot dy"></div><div class="bd">'
+        f'<details><summary>Thinking</summary>'
+        f'<div class="thk">{html.escape(thinking[:BLOCK_TRUNCATE])}</div>'
+        "</details></div></li>"
+    )
+
+
+def render_text(text: str) -> str:
+    return (
+        '<li class="step"><div class="dot dg"></div>'
+        f'<div class="bd"><div class="tx">{ansi_to_html(text[:BLOCK_TRUNCATE])}</div></div></li>'
+    )
+
+
+def render_user_text(text: str) -> str:
+    return (
+        '<li class="step"><div class="dot db"></div>'
+        '<div class="bd"><div class="user-msg"><div class="tt">User</div>'
+        f'<div class="tx">{ansi_to_html(text[:BLOCK_TRUNCATE])}</div></div></div></li>'
+    )
+
+
+def render_tool(tool_use: dict, tool_result: dict | None, shell_tool_names: frozenset[str]) -> str:
+    name = tool_use.get("name", "tool")
+    inp = tool_use.get("input", {})
+
+    if name in shell_tool_names:
+        cmd = inp.get("command", "")
+        label = (cmd.split("\n")[0] if cmd else "")[:80]
+        out_html = ""
+        if tool_result is not None:
+            c = tool_result.get("content", "")
+            out = (
+                "\n".join(b.get("text", "") for b in c if isinstance(b, dict))
+                if isinstance(c, list)
+                else str(c)
+            )
+            out_html = (
+                '<div class="iotag">OUT</div>'
+                f'<div class="iopre">{ansi_to_html(out[:BLOCK_TRUNCATE])}</div>'
+            )
+        return (
+            '<li class="step"><div class="dot dg"></div><div class="bd">'
+            f'<div class="tt">{html.escape(name.capitalize())}<span class="lb">{html.escape(label)}</span></div>'
+            '<div class="io">'
+            '<div class="iotag">IN</div>'
+            f'<div class="iopre">{html.escape(cmd[:BLOCK_TRUNCATE])}</div>'
+            f"{out_html}"
+            "</div></div></li>"
+        )
+
+    if name == "TodoWrite":
+        todos = inp.get("todos", [])
+        items = []
+        for todo in todos[:30]:
+            done = todo.get("status") == "completed"
+            check = "☑" if done else "☐"
+            cls = "todo done" if done else "todo"
+            items.append(
+                f'<div class="{cls}"><span>{check}</span>{html.escape(todo.get("content", ""))}</div>'
+            )
+        return (
+            '<li class="step"><div class="dot dg"></div><div class="bd">'
+            '<div class="tt">Update Todos</div>'
+            f'<div class="todos">{"".join(items)}</div>'
+            "</div></li>"
+        )
+
+    label = inp.get("skill", inp.get("name", "")) if name == "Skill" else ""
+    return (
+        '<li class="step"><div class="dot dg"></div><div class="bd">'
+        f'<div class="tt">{html.escape(name)}'
+        + (f'<span class="lb">{html.escape(str(label))}</span>' if label else "")
+        + "</div></div></li>"
+    )
+
+
+def render_transcript_html(
+    entries: list[dict],
+    *,
+    is_bookkeeping_bash_cmd: Callable[[str], bool],
+    skill_marker: str,
+    shell_tool_names: frozenset[str] = frozenset({"Bash"}),
+) -> str:
+    def content_has_marker(content: object, marker: str) -> bool:
+        if isinstance(content, str):
+            return marker in content
+        if isinstance(content, list):
+            return any(
+                isinstance(b, dict) and b.get("type") == "text" and marker in b.get("text", "")
+                for b in content
+            )
+        return False
+
+    filtered = [msg for msg in entries if not content_has_marker(msg.get("content"), skill_marker)]
+
+    bookkeeping_ids: set[str] = {
+        block.get("id", "")
+        for msg in filtered
+        for block in (msg.get("content") or [])
+        if isinstance(block, dict)
+        and block.get("type") == "tool_use"
+        and block.get("name") in shell_tool_names
+        and is_bookkeeping_bash_cmd(block.get("input", {}).get("command", ""))
+    }
+
+    tool_use_map: dict[str, dict] = {
+        block.get("id", ""): block
+        for msg in filtered
+        for block in (msg.get("content") or [])
+        if isinstance(block, dict) and block.get("type") == "tool_use" and block.get("id")
+    }
+
+    paired_ids: set[str] = set()
+    steps: list[str] = []
+
+    for msg in filtered:
+        role = msg.get("role", "")
+        content = msg.get("content")
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}]
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            btype = block.get("type")
+            if btype == "tool_use":
+                continue  # rendered when paired tool_result is seen
+            if btype == "tool_result":
+                use_id = block.get("tool_use_id", "")
+                if use_id in bookkeeping_ids:
+                    continue
+                tool_use = tool_use_map.get(use_id, {})
+                paired_ids.add(use_id)
+                steps.append(render_tool(tool_use, block, shell_tool_names))
+            elif btype == "thinking" and role == "assistant":
+                thinking = block.get("thinking", "").strip()
+                if thinking:
+                    steps.append(render_thinking(thinking))
+            elif btype == "text" and role == "assistant":
+                text = block.get("text", "").strip()
+                if text:
+                    steps.append(render_text(text))
+            elif btype == "text" and role == "user":
+                text = block.get("text", "").strip()
+                if text:
+                    steps.append(render_user_text(text))
+
+    # render any tool_use blocks that never got a result (session interrupted)
+    for uid, tool_use in tool_use_map.items():
+        if uid not in paired_ids and uid not in bookkeeping_ids:
+            steps.append(render_tool(tool_use, None, shell_tool_names))
+
+    return HTML_TEMPLATE.format(steps="\n".join(steps))
+
+
+# --- transform stamping ---
+# The primary path (child runs linked via LAMIN_INITIATED_BY_RUN_UID) is fully
+# agent-agnostic. The fallback path (scanning the transcript for write/edit
+# tool calls) needs each agent's own tool-name/path-key conventions.
+
+
+def extract_written_script_paths(
+    entries: list[dict],
+    *,
+    script_tool_names: frozenset[str],
+    script_path_keys: tuple[str, ...],
+    suffix_to_kind: dict[str, str],
+):
+    from pathlib import Path
+
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for msg in entries:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if block.get("type") != "tool_use" or block.get("name") not in script_tool_names:
+                continue
+            inp = block.get("input", {})
+            file_path = next((inp.get(k) for k in script_path_keys if inp.get(k)), None)
+            if not isinstance(file_path, str):
+                continue
+            p = Path(file_path)
+            if p.suffix not in suffix_to_kind:
+                continue
+            key = str(p)
+            if key not in seen:
+                seen.add(key)
+                paths.append(p)
+    return paths
+
+
+def stamp_transforms(
+    run: object,
+    entries: list[dict],
+    ln: object,
+    *,
+    script_tool_names: frozenset[str] = frozenset(),
+    script_path_keys: tuple[str, ...] = (),
+    suffix_to_kind: dict[str, str] | None = None,
+) -> None:
+    # Primary path: scripts run with LAMIN_INITIATED_BY_RUN_UID create child runs.
+    already_stamped: set[str] = set()
+    for child_run in run.initiated_runs.all():  # type: ignore[attr-defined]
+        t = child_run.transform
+        already_stamped.add(t.key)
+        if t.run_id is None:
+            t.run = run
+            t.save()
+
+    if not suffix_to_kind:
+        return
+
+    for path in extract_written_script_paths(
+        entries,
+        script_tool_names=script_tool_names,
+        script_path_keys=script_path_keys,
+        suffix_to_kind=suffix_to_kind,
+    ):
+        if not path.exists() or path.name in already_stamped:
+            continue
+        kind = suffix_to_kind[path.suffix]
+        transform = ln.Transform.filter(key=path.name).one_or_none()  # type: ignore[attr-defined]
+        if transform is None:
+            transform = ln.Transform(key=path.name, kind=kind)  # type: ignore[attr-defined]
+            transform.save()
+        if transform.run_id is None:
+            transform.run = run
+            transform.save()
+            info(f"registered transform: {path.name}")

--- a/lamin_cli/agents/_common.py
+++ b/lamin_cli/agents/_common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html
 import re
+from pathlib import Path
 from typing import Callable
 
 import click
@@ -119,6 +120,22 @@ def instance_connected(ln: object) -> bool:
     if hasattr(s, "is_configured"):
         return bool(s.is_configured)
     return bool(s._instance_exists)
+
+
+def resolve_state_dir(name: str) -> Path:
+    """Base directory for agent state files.
+
+    Prefers the instance's configured dev-dir over cwd, so `track <agent>` and
+    `track finish` agree on the same location even if invoked from different
+    working directories within the same session.
+    """
+    try:
+        from lamindb_setup import settings as ln_setup_settings
+
+        dev_dir = ln_setup_settings.dev_dir
+    except Exception:
+        dev_dir = None
+    return Path(dev_dir) / name if dev_dir is not None else Path(name)
 
 
 # --- HTML rendering ---
@@ -297,8 +314,6 @@ def extract_written_script_paths(
     script_path_keys: tuple[str, ...],
     suffix_to_kind: dict[str, str],
 ):
-    from pathlib import Path
-
     paths: list[Path] = []
     seen: set[str] = set()
     for msg in entries:
@@ -331,8 +346,6 @@ def stamp_transforms(
     script_path_keys: tuple[str, ...] = (),
     suffix_to_kind: dict[str, str] | None = None,
 ) -> None:
-    from pathlib import Path
-
     # Primary path: scripts run with LAMIN_INITIATED_BY_RUN_UID create child runs.
     already_stamped: set[str] = set()
     for child_run in run.initiated_runs.all():  # type: ignore[attr-defined]

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -39,11 +39,13 @@ body{{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#
 ul{{list-style:none}}
 li.step{{display:flex;align-items:flex-start;gap:10px;padding:3px 0}}
 .dot{{width:8px;height:8px;border-radius:50%;flex-shrink:0;margin-top:6px}}
-.dg{{background:#23d18b}}.dy{{background:#bbb}}
+.dg{{background:#23d18b}}.dy{{background:#bbb}}.db{{background:#2472c8}}
 .bd{{flex:1;min-width:0}}
 .tt{{font-weight:600;color:#111}}
 .lb{{font-weight:400;color:#888;font-size:.85em;margin-left:6px}}
 .tx{{white-space:pre-wrap;word-wrap:break-word;color:#333;margin-top:2px}}
+.user-msg{{background:#eef4fd;border-radius:6px;padding:8px 10px;margin:2px 0}}
+.user-msg .tt{{color:#2472c8;font-size:.8rem;text-transform:uppercase;letter-spacing:.04em;margin-bottom:2px}}
 .io{{margin-top:6px;border-radius:4px;border:1px solid #e5e5e5;overflow:hidden;font-family:ui-monospace,monospace;font-size:.82rem}}
 .iotag{{padding:2px 8px;background:#f5f5f5;color:#888;font-size:.72rem;font-weight:700;letter-spacing:.08em}}
 .iopre{{padding:6px 10px;background:#fafafa;white-space:pre-wrap;word-wrap:break-word;color:#333}}
@@ -265,6 +267,14 @@ def _render_text(text: str) -> str:
     )
 
 
+def _render_user_text(text: str) -> str:
+    return (
+        '<li class="step"><div class="dot db"></div>'
+        '<div class="bd"><div class="user-msg"><div class="tt">User</div>'
+        f'<div class="tx">{_ansi_to_html(text[:_BLOCK_TRUNCATE])}</div></div></div></li>'
+    )
+
+
 def _render_tool(tool_use: dict, tool_result: dict | None) -> str:
     name = tool_use.get("name", "tool")
     inp = tool_use.get("input", {})
@@ -373,6 +383,10 @@ def _render_transcript_html(entries: list[dict]) -> str:
                 text = block.get("text", "").strip()
                 if text:
                     steps.append(_render_text(text))
+            elif btype == "text" and role == "user":
+                text = block.get("text", "").strip()
+                if text:
+                    steps.append(_render_user_text(text))
 
     # render any tool_use blocks that never got a result (session interrupted)
     for uid, tool_use in tool_use_map.items():

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -101,12 +101,7 @@ def track_claudecode_session(name: str | None = None) -> None:
 
 
 def _is_bookkeeping_bash_cmd(cmd: str) -> bool:
-    if "lamin track claude" in cmd or "lamin track finish" in cmd:
-        return True
-    # legacy: inline python -c form
-    return ("ln.Transform(" in cmd and "ln.Run(transform)" in cmd) or (
-        "ln.Run.get(uid=" in cmd and "report" in cmd.lower()
-    )
+    return False
 
 
 def _parse_transcript(transcript_path: Path) -> list[dict]:

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -178,6 +178,7 @@ def finish_claudecode_session() -> None:
             artifact = ln.Artifact(
                 tmp.name,
                 description="Claude Code session transcript (rendered)",
+                kind="__lamindb_run__",
                 run=False,
             ).save()
         finally:

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import html
 import json
 import os
-import re
 import tempfile
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
-import click
+from lamin_cli.agents import _common
 
 # --- constants ---
 
@@ -17,7 +15,7 @@ _CLAUDE_DIR = Path(".claude")
 _TRANSFORM_KEY = "__claudecode__"
 _TRANSFORM_UID = "SnfuhjObaAKR0000"
 _SKILL_MARKER = "Base directory for this skill:"
-_BLOCK_TRUNCATE = 4000
+_SHELL_TOOL_NAMES = frozenset({"Bash"})
 
 _SUFFIX_TO_KIND: dict[str, str] = {
     ".ipynb": "notebook",
@@ -27,106 +25,8 @@ _SUFFIX_TO_KIND: dict[str, str] = {
     ".qmd": "script",
 }
 
-_SCRIPT_TOOL_NAMES = {"Write", "Edit", "NotebookEdit"}
+_SCRIPT_TOOL_NAMES = frozenset({"Write", "Edit", "NotebookEdit"})
 _SCRIPT_PATH_KEYS = ("file_path", "path", "notebook_path")
-
-_HTML_TEMPLATE = """\
-<!doctype html>
-<html><head><meta charset="utf-8"><title>Session Transcript</title>
-<style>
-*{{box-sizing:border-box;margin:0;padding:0}}
-body{{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111;max-width:800px;margin:0 auto;padding:1.5rem;font-size:14px;line-height:1.5}}
-ul{{list-style:none}}
-li.step{{display:flex;align-items:flex-start;gap:10px;padding:3px 0}}
-.dot{{width:8px;height:8px;border-radius:50%;flex-shrink:0;margin-top:6px}}
-.dg{{background:#23d18b}}.dy{{background:#bbb}}
-.bd{{flex:1;min-width:0}}
-.tt{{font-weight:600;color:#111}}
-.lb{{font-weight:400;color:#888;font-size:.85em;margin-left:6px}}
-.tx{{white-space:pre-wrap;word-wrap:break-word;color:#333;margin-top:2px}}
-.io{{margin-top:6px;border-radius:4px;border:1px solid #e5e5e5;overflow:hidden;font-family:ui-monospace,monospace;font-size:.82rem}}
-.iotag{{padding:2px 8px;background:#f5f5f5;color:#888;font-size:.72rem;font-weight:700;letter-spacing:.08em}}
-.iopre{{padding:6px 10px;background:#fafafa;white-space:pre-wrap;word-wrap:break-word;color:#333}}
-details summary{{cursor:pointer;color:#888;font-size:.85rem;list-style:none}}
-details summary::-webkit-details-marker{{display:none}}
-details summary::before{{content:'▶ ';font-size:.7em}}
-details[open] summary::before{{content:'▼ '}}
-.thk{{margin-top:4px;color:#666;font-size:.85rem;white-space:pre-wrap;word-wrap:break-word;padding-left:8px;border-left:2px solid #e5e5e5}}
-.todos{{margin-top:4px}}
-.todo{{display:flex;gap:6px;color:#333;font-size:.88rem;padding:1px 0}}
-.done{{color:#aaa;text-decoration:line-through}}
-</style></head>
-<body><ul>
-{steps}
-</ul></body></html>"""
-
-_ANSI_SGR = re.compile(r"\x1b\[([0-9;]*)m")
-_ANSI_BASE_COLORS = ["#000","#cd3131","#0dbc79","#e5e510","#2472c8","#bc3fbc","#11a8cd","#e5e5e5"]
-_ANSI_BRIGHT_COLORS = ["#666","#f14c4c","#23d18b","#f5f543","#3b8eea","#d670d6","#29b8db","#fff"]
-
-
-def _ansi_to_html(text: str) -> str:
-    """Convert ANSI SGR color codes to HTML spans; HTML-escape all other text."""
-    result: list[str] = []
-    style: dict[str, str] = {}
-    span_open = False
-    cursor = 0
-
-    def css(s: dict[str, str]) -> str:
-        parts = []
-        if "fg" in s:
-            parts.append(f"color:{s['fg']}")
-        if "bg" in s:
-            parts.append(f"background:{s['bg']}")
-        if s.get("bold"):
-            parts.append("font-weight:700")
-        return ";".join(parts)
-
-    for m in _ANSI_SGR.finditer(text):
-        result.append(html.escape(text[cursor:m.start()]))
-        cursor = m.end()
-        codes = [int(c) for c in m.group(1).split(";") if c] if m.group(1) else [0]
-        i = 0
-        while i < len(codes):
-            c = codes[i]
-            if c == 0:
-                style = {}
-            elif c == 1:
-                style["bold"] = "1"
-            elif 30 <= c <= 37:
-                style["fg"] = _ANSI_BASE_COLORS[c - 30]
-            elif 90 <= c <= 97:
-                style["fg"] = _ANSI_BRIGHT_COLORS[c - 90]
-            elif 40 <= c <= 47:
-                style["bg"] = _ANSI_BASE_COLORS[c - 40]
-            elif c == 39:
-                style.pop("fg", None)
-            elif c == 49:
-                style.pop("bg", None)
-            i += 1
-        new_css = css(style)
-        if span_open:
-            result.append("</span>")
-            span_open = False
-        if new_css:
-            result.append(f'<span style="{new_css}">')
-            span_open = True
-
-    result.append(html.escape(text[cursor:]))
-    if span_open:
-        result.append("</span>")
-    return "".join(result)
-
-
-# --- output helpers ---
-
-
-def _info(msg: str) -> None:
-    click.echo(f"✓ {msg}")
-
-
-def _warn(msg: str) -> None:
-    click.echo(f"! {msg}", err=True)
 
 
 # --- lamindb helpers ---
@@ -161,13 +61,6 @@ def _get_transcript_path() -> Path:
     return matches[0] if matches else candidate
 
 
-def _instance_connected(ln: object) -> bool:
-    s = ln.setup.settings  # type: ignore[attr-defined]
-    if hasattr(s, "is_configured"):
-        return bool(s.is_configured)
-    return bool(s._instance_exists)
-
-
 # --- session start ---
 
 
@@ -175,12 +68,12 @@ def track_claudecode_session(name: str | None = None) -> None:
     try:
         import lamindb as ln
     except Exception as e:
-        _warn(f"lamindb not available, skipping session tracking: {e}")
+        _common.warn(f"lamindb not available, skipping session tracking: {e}")
         return
 
     try:
-        if not _instance_connected(ln):
-            _warn("no lamindb instance connected, skipping session tracking")
+        if not _common.instance_connected(ln):
+            _common.warn("no lamindb instance connected, skipping session tracking")
             return
 
         transform = ln.Transform.filter(uid=_TRANSFORM_UID).one_or_none()
@@ -199,25 +92,12 @@ def track_claudecode_session(name: str | None = None) -> None:
         _CLAUDE_DIR.mkdir(exist_ok=True)
         _run_uid_file().write_text(run.uid)
         _transcript_path_file().write_text(str(_get_transcript_path()))
-        _info(f"started tracking Claude Code session: {run.uid}")
+        _common.info(f"started tracking Claude Code session: {run.uid}")
     except Exception as e:
-        _warn(f"lamindb session tracking failed, continuing without tracking: {e}")
+        _common.warn(f"lamindb session tracking failed, continuing without tracking: {e}")
 
 
 # --- transcript parsing ---
-
-
-def _content_has_marker(content: object, marker: str) -> bool:
-    if isinstance(content, str):
-        return marker in content
-    if isinstance(content, list):
-        return any(
-            isinstance(b, dict)
-            and b.get("type") == "text"
-            and marker in b.get("text", "")
-            for b in content
-        )
-    return False
 
 
 def _is_bookkeeping_bash_cmd(cmd: str) -> bool:
@@ -246,198 +126,6 @@ def _parse_transcript(transcript_path: Path) -> list[dict]:
     return entries
 
 
-# --- HTML rendering ---
-
-
-def _render_thinking(thinking: str) -> str:
-    return (
-        '<li class="step"><div class="dot dy"></div><div class="bd">'
-        f'<details><summary>Thinking</summary>'
-        f'<div class="thk">{html.escape(thinking[:_BLOCK_TRUNCATE])}</div>'
-        "</details></div></li>"
-    )
-
-
-def _render_text(text: str) -> str:
-    return (
-        '<li class="step"><div class="dot dg"></div>'
-        f'<div class="bd"><div class="tx">{_ansi_to_html(text[:_BLOCK_TRUNCATE])}</div></div></li>'
-    )
-
-
-def _render_tool(tool_use: dict, tool_result: dict | None) -> str:
-    name = tool_use.get("name", "tool")
-    inp = tool_use.get("input", {})
-
-    if name == "Bash":
-        cmd = inp.get("command", "")
-        label = (cmd.split("\n")[0] if cmd else "")[:80]
-        out_html = ""
-        if tool_result is not None:
-            c = tool_result.get("content", "")
-            out = (
-                "\n".join(b.get("text", "") for b in c if isinstance(b, dict))
-                if isinstance(c, list)
-                else str(c)
-            )
-            out_html = (
-                '<div class="iotag">OUT</div>'
-                f'<div class="iopre">{_ansi_to_html(out[:_BLOCK_TRUNCATE])}</div>'
-            )
-        return (
-            '<li class="step"><div class="dot dg"></div><div class="bd">'
-            f'<div class="tt">Bash<span class="lb">{html.escape(label)}</span></div>'
-            '<div class="io">'
-            '<div class="iotag">IN</div>'
-            f'<div class="iopre">{html.escape(cmd[:_BLOCK_TRUNCATE])}</div>'
-            f"{out_html}"
-            "</div></div></li>"
-        )
-
-    if name == "TodoWrite":
-        todos = inp.get("todos", [])
-        items = []
-        for todo in todos[:30]:
-            done = todo.get("status") == "completed"
-            check = "☑" if done else "☐"
-            cls = "todo done" if done else "todo"
-            items.append(
-                f'<div class="{cls}"><span>{check}</span>{html.escape(todo.get("content", ""))}</div>'
-            )
-        return (
-            '<li class="step"><div class="dot dg"></div><div class="bd">'
-            '<div class="tt">Update Todos</div>'
-            f'<div class="todos">{"".join(items)}</div>'
-            "</div></li>"
-        )
-
-    label = inp.get("skill", inp.get("name", "")) if name == "Skill" else ""
-    return (
-        '<li class="step"><div class="dot dg"></div><div class="bd">'
-        f'<div class="tt">{html.escape(name)}'
-        + (f'<span class="lb">{html.escape(str(label))}</span>' if label else "")
-        + "</div></div></li>"
-    )
-
-
-def _render_transcript_html(entries: list[dict]) -> str:
-    filtered = [
-        msg
-        for msg in entries
-        if not _content_has_marker(msg.get("content"), _SKILL_MARKER)
-    ]
-
-    bookkeeping_ids: set[str] = {
-        block.get("id", "")
-        for msg in filtered
-        for block in (msg.get("content") or [])
-        if isinstance(block, dict)
-        and block.get("type") == "tool_use"
-        and block.get("name") == "Bash"
-        and _is_bookkeeping_bash_cmd(block.get("input", {}).get("command", ""))
-    }
-
-    tool_use_map: dict[str, dict] = {
-        block.get("id", ""): block
-        for msg in filtered
-        for block in (msg.get("content") or [])
-        if isinstance(block, dict) and block.get("type") == "tool_use" and block.get("id")
-    }
-
-    paired_ids: set[str] = set()
-    steps: list[str] = []
-
-    for msg in filtered:
-        role = msg.get("role", "")
-        content = msg.get("content")
-        if isinstance(content, str):
-            content = [{"type": "text", "text": content}]
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            btype = block.get("type")
-            if btype == "tool_use":
-                continue  # rendered when paired tool_result is seen
-            if btype == "tool_result":
-                use_id = block.get("tool_use_id", "")
-                if use_id in bookkeeping_ids:
-                    continue
-                tool_use = tool_use_map.get(use_id, {})
-                paired_ids.add(use_id)
-                steps.append(_render_tool(tool_use, block))
-            elif btype == "thinking" and role == "assistant":
-                thinking = block.get("thinking", "").strip()
-                if thinking:
-                    steps.append(_render_thinking(thinking))
-            elif btype == "text" and role == "assistant":
-                text = block.get("text", "").strip()
-                if text:
-                    steps.append(_render_text(text))
-
-    # render any tool_use blocks that never got a result (session interrupted)
-    for uid, tool_use in tool_use_map.items():
-        if uid not in paired_ids and uid not in bookkeeping_ids:
-            steps.append(_render_tool(tool_use, None))
-
-    return _HTML_TEMPLATE.format(steps="\n".join(steps))
-
-
-# --- transform stamping ---
-
-
-def _extract_written_script_paths(entries: list[dict]) -> list[Path]:
-    paths: list[Path] = []
-    seen: set[str] = set()
-    for msg in entries:
-        content = msg.get("content")
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            if (
-                block.get("type") != "tool_use"
-                or block.get("name") not in _SCRIPT_TOOL_NAMES
-            ):
-                continue
-            inp = block.get("input", {})
-            file_path = next(
-                (inp.get(k) for k in _SCRIPT_PATH_KEYS if inp.get(k)), None
-            )
-            if not isinstance(file_path, str):
-                continue
-            p = Path(file_path)
-            if p.suffix not in _SUFFIX_TO_KIND:
-                continue
-            key = str(p)
-            if key not in seen:
-                seen.add(key)
-                paths.append(p)
-    return paths
-
-
-def _stamp_transforms(run: object, entries: list[dict], ln: object) -> None:
-    # Primary path: scripts run with LAMIN_INITIATED_BY_RUN_UID create child runs
-    already_stamped: set[str] = set()
-    for child_run in run.initiated_runs.all():  # type: ignore[attr-defined]
-        t = child_run.transform
-        already_stamped.add(t.key)
-        if t.run_id is None:
-            t.run = run
-            t.save()
-
-    for path in _extract_written_script_paths(entries):
-        if not path.exists() or path.name in already_stamped:
-            continue
-        kind = _SUFFIX_TO_KIND[path.suffix]
-        transform = ln.Transform.filter(key=path.name).one_or_none()  # type: ignore[attr-defined]
-        if transform is None:
-            transform = ln.Transform(key=path.name, kind=kind)  # type: ignore[attr-defined]
-            transform.save()
-        if transform.run_id is None:
-            transform.run = run
-            transform.save()
-            _info(f"registered transform: {path.name}")
-
-
 # --- session finish ---
 
 
@@ -445,17 +133,17 @@ def finish_claudecode_session() -> None:
     try:
         import lamindb as ln
     except Exception as e:
-        _warn(f"lamindb not available, skipping session finish: {e}")
+        _common.warn(f"lamindb not available, skipping session finish: {e}")
         return
 
     try:
-        if not _instance_connected(ln):
-            _warn("no lamindb instance connected, skipping session finish")
+        if not _common.instance_connected(ln):
+            _common.warn("no lamindb instance connected, skipping session finish")
             return
 
         run_uid_file = _run_uid_file()
         if not run_uid_file.exists():
-            _warn("no active Claude Code session found, skipping session finish")
+            _common.warn("no active Claude Code session found, skipping session finish")
             return
 
         uid = run_uid_file.read_text().strip()
@@ -468,7 +156,7 @@ def finish_claudecode_session() -> None:
             transcript_path = _get_transcript_path()
 
         if not transcript_path.exists():
-            _warn(
+            _common.warn(
                 f"transcript file not found: {transcript_path} — "
                 "closing run without report (is CLAUDE_CODE_SESSION_ID set?)"
             )
@@ -480,7 +168,12 @@ def finish_claudecode_session() -> None:
             return
 
         entries = _parse_transcript(transcript_path)
-        html_doc = _render_transcript_html(entries)
+        html_doc = _common.render_transcript_html(
+            entries,
+            is_bookkeeping_bash_cmd=_is_bookkeeping_bash_cmd,
+            skill_marker=_SKILL_MARKER,
+            shell_tool_names=_SHELL_TOOL_NAMES,
+        )
 
         tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False)
         tmp_path = Path(tmp.name)
@@ -496,7 +189,14 @@ def finish_claudecode_session() -> None:
             tmp_path.unlink(missing_ok=True)
 
         run.report = artifact
-        _stamp_transforms(run, entries, ln)
+        _common.stamp_transforms(
+            run,
+            entries,
+            ln,
+            script_tool_names=_SCRIPT_TOOL_NAMES,
+            script_path_keys=_SCRIPT_PATH_KEYS,
+            suffix_to_kind=_SUFFIX_TO_KIND,
+        )
 
         run._status_code = 0  # completed
         run.finished_at = datetime.now(timezone.utc)
@@ -504,7 +204,7 @@ def finish_claudecode_session() -> None:
 
         run_uid_file.unlink()
         _transcript_path_file().unlink()
-        _info(f"finished tracking Claude Code session: {run.uid}")
+        _common.info(f"finished tracking Claude Code session: {run.uid}")
     except Exception as e:
-        _warn(f"lamindb session finish failed, continuing: {e}")
-        _warn(traceback.format_exc())
+        _common.warn(f"lamindb session finish failed, continuing: {e}")
+        _common.warn(traceback.format_exc())

--- a/lamin_cli/agents/claude.py
+++ b/lamin_cli/agents/claude.py
@@ -11,7 +11,6 @@ from lamin_cli.agents import _common
 
 # --- constants ---
 
-_CLAUDE_DIR = Path(".claude")
 _TRANSFORM_KEY = "__claudecode__"
 _TRANSFORM_UID = "SnfuhjObaAKR0000"
 _SKILL_MARKER = "Base directory for this skill:"
@@ -36,12 +35,16 @@ def _session_id() -> str:
     return os.environ.get("CLAUDE_CODE_SESSION_ID", "default")
 
 
+def _claude_dir() -> Path:
+    return _common.resolve_state_dir(".claude")
+
+
 def _run_uid_file() -> Path:
-    return _CLAUDE_DIR / f".lamindb_run_uid_{_session_id()}"
+    return _claude_dir() / f".lamindb_run_uid_{_session_id()}"
 
 
 def _transcript_path_file() -> Path:
-    return _CLAUDE_DIR / f".lamindb_transcript_path_{_session_id()}"
+    return _claude_dir() / f".lamindb_transcript_path_{_session_id()}"
 
 
 def _get_transcript_path() -> Path:
@@ -89,7 +92,7 @@ def track_claudecode_session(name: str | None = None) -> None:
 
         run = ln.Run(transform, status="started", name=name).save()
 
-        _CLAUDE_DIR.mkdir(exist_ok=True)
+        _claude_dir().mkdir(parents=True, exist_ok=True)
         _run_uid_file().write_text(run.uid)
         _transcript_path_file().write_text(str(_get_transcript_path()))
         _common.info(f"started tracking Claude Code session: {run.uid}")

--- a/lamin_cli/agents/copilot.py
+++ b/lamin_cli/agents/copilot.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lamin_cli.agents import _common
+
+# --- constants ---
+
+_STATE_DIR = Path(".claude")
+_TRANSFORM_KEY = "__copilot__"
+_TRANSFORM_UID = "vl12ppCqQp2P0000"
+_SKILL_MARKER = "Base directory for this skill:"
+_SHELL_TOOL_NAMES = frozenset({"bash"})
+
+# Copilot's write/edit tool naming hasn't been directly observed yet, so the
+# transcript-scan fallback for transform stamping is left empty — the primary
+# path (child runs linked via LAMIN_INITIATED_BY_RUN_UID) is what matters and
+# is fully agent-agnostic already. Fill these in once verified against real
+# Copilot sessions that write files via a dedicated tool rather than bash.
+_SCRIPT_TOOL_NAMES: frozenset[str] = frozenset()
+_SCRIPT_PATH_KEYS: tuple[str, ...] = ()
+_SUFFIX_TO_KIND: dict[str, str] = {}
+
+_SELF_MATCH_WINDOW_SECONDS = 5.0
+
+
+# --- session resolution ---
+# Copilot has no equivalent of $CLAUDE_CODE_SESSION_ID, so "which session is
+# this" has to be resolved rather than read directly. Two strategies, tried
+# in order:
+#
+# 1. Self-invocation match: this process's own command text (e.g. "lamin
+#    track copilot") gets logged by Copilot to that session's events.jsonl
+#    as a tool.execution_start *before* this code even starts running
+#    (verified empirically: ~1ms after the tool call is issued, tens of ms
+#    before the shell actually executes) — so searching for a recent event
+#    containing that text reliably identifies which session issued this
+#    exact call, even with multiple sessions active in the same directory.
+# 2. Workspace scan fallback: match workspace.yaml's cwd against Path.cwd(),
+#    pick the most recently updated one. Only a heuristic, but it's the
+#    fallback path, not the primary one, and only matters if the log-based
+#    match somehow finds nothing (e.g. a very old/stale invocation).
+
+
+def _copilot_session_state_dir() -> Path:
+    return Path.home() / ".copilot" / "session-state"
+
+
+def _resolve_session_via_self_invocation(
+    match_text: str, window_seconds: float = _SELF_MATCH_WINDOW_SECONDS
+) -> str | None:
+    state_dir = _copilot_session_state_dir()
+    if not state_dir.exists():
+        return None
+
+    now = datetime.now(timezone.utc).timestamp()
+    best_id: str | None = None
+    best_ts = -1.0
+
+    for session_dir in state_dir.iterdir():
+        events_file = session_dir / "events.jsonl"
+        if not events_file.exists():
+            continue
+        try:
+            lines = events_file.read_text().splitlines()
+        except OSError:
+            continue
+        # only the tail is relevant; this call was issued very recently
+        for line in reversed(lines[-50:]):
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") != "tool.execution_start":
+                continue
+            cmd = entry.get("data", {}).get("arguments", {}).get("command", "")
+            if match_text not in cmd:
+                continue
+            ts_str = entry.get("timestamp", "")
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                continue
+            if now - ts > window_seconds:
+                continue
+            if ts > best_ts:
+                best_ts = ts
+                best_id = session_dir.name
+
+    return best_id
+
+
+def _resolve_session_via_workspace_scan() -> str | None:
+    state_dir = _copilot_session_state_dir()
+    if not state_dir.exists():
+        return None
+
+    cwd = str(Path.cwd())
+    best_id: str | None = None
+    best_updated = ""
+
+    for session_dir in state_dir.iterdir():
+        wf = session_dir / "workspace.yaml"
+        if not wf.exists():
+            continue
+        try:
+            text = wf.read_text()
+        except OSError:
+            continue
+        data: dict[str, str] = {}
+        for line in text.splitlines():
+            if ":" in line:
+                k, _, v = line.partition(":")
+                data[k.strip()] = v.strip()
+        if data.get("cwd") != cwd:
+            continue
+        updated = data.get("updated_at", "")
+        if updated > best_updated:
+            best_updated = updated
+            best_id = session_dir.name
+
+    return best_id
+
+
+def _resolve_session(match_text: str) -> str | None:
+    return _resolve_session_via_self_invocation(match_text) or _resolve_session_via_workspace_scan()
+
+
+def _run_uid_file(session_id: str) -> Path:
+    return _STATE_DIR / f".lamindb_run_uid_copilot_{session_id}"
+
+
+def _transcript_path(session_id: str) -> Path:
+    return _copilot_session_state_dir() / session_id / "events.jsonl"
+
+
+# --- session start ---
+
+
+def track_copilot_session(name: str | None = None) -> None:
+    try:
+        import lamindb as ln
+    except Exception as e:
+        _common.warn(f"lamindb not available, skipping session tracking: {e}")
+        return
+
+    try:
+        if not _common.instance_connected(ln):
+            _common.warn("no lamindb instance connected, skipping session tracking")
+            return
+
+        session_id = _resolve_session("lamin track copilot")
+        if session_id is None:
+            _common.warn("could not resolve the active Copilot session, skipping session tracking")
+            return
+
+        transform = ln.Transform.filter(uid=_TRANSFORM_UID).one_or_none()
+        if transform is None:
+            transform, _ = ln.Transform.objects.get_or_create(
+                uid=_TRANSFORM_UID,
+                defaults={
+                    "key": _TRANSFORM_KEY,
+                    "kind": "function",
+                    "description": "A Copilot session.",
+                },
+            )
+
+        run = ln.Run(transform, status="started", name=name).save()
+
+        _STATE_DIR.mkdir(exist_ok=True)
+        _run_uid_file(session_id).write_text(run.uid)
+        _common.info(f"started tracking Copilot session: {run.uid}")
+    except Exception as e:
+        _common.warn(f"lamindb session tracking failed, continuing without tracking: {e}")
+
+
+# --- transcript parsing ---
+# Normalizes Copilot's native event shape into the same {"role", "content":
+# [...]} shape claude.py's transcript already uses, so _common.py's renderer
+# and transform-stamping logic work unchanged for both agents.
+
+
+def _is_bookkeeping_bash_cmd(cmd: str) -> bool:
+    return "lamin track copilot" in cmd or "lamin track finish" in cmd
+
+
+def _parse_transcript(transcript_path: Path) -> list[dict]:
+    raw_events: list[dict] = []
+    with transcript_path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                raw_events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    results_by_call_id: dict[str, object] = {}
+    for event in raw_events:
+        if event.get("type") == "tool.execution_complete":
+            data = event.get("data", {})
+            call_id = data.get("toolCallId")
+            if call_id:
+                results_by_call_id[call_id] = data.get("result", {}).get("content", "")
+
+    entries: list[dict] = []
+    for event in raw_events:
+        etype = event.get("type")
+        data = event.get("data", {})
+
+        if etype == "user.message":
+            text = data.get("content", "")
+            if isinstance(text, str) and text.strip():
+                entries.append({"role": "user", "content": [{"type": "text", "text": text}]})
+
+        elif etype == "assistant.message":
+            content_blocks: list[dict] = []
+            text = data.get("content", "")
+            if isinstance(text, str) and text.strip():
+                content_blocks.append({"type": "text", "text": text})
+            for tool_req in data.get("toolRequests", []) or []:
+                call_id = tool_req.get("toolCallId", "")
+                content_blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": call_id,
+                        "name": tool_req.get("name", "tool"),
+                        "input": tool_req.get("arguments", {}),
+                    }
+                )
+                if call_id in results_by_call_id:
+                    content_blocks.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call_id,
+                            "content": results_by_call_id[call_id],
+                        }
+                    )
+            if content_blocks:
+                entries.append({"role": "assistant", "content": content_blocks})
+
+    return entries
+
+
+# --- session finish ---
+
+
+def finish_copilot_session() -> None:
+    try:
+        import lamindb as ln
+    except Exception as e:
+        _common.warn(f"lamindb not available, skipping session finish: {e}")
+        return
+
+    try:
+        if not _common.instance_connected(ln):
+            _common.warn("no lamindb instance connected, skipping session finish")
+            return
+
+        candidates = sorted(_STATE_DIR.glob(".lamindb_run_uid_copilot_*"))
+        if not candidates:
+            _common.warn("no active Copilot session found, skipping session finish")
+            return
+
+        if len(candidates) == 1:
+            run_uid_file = candidates[0]
+        else:
+            session_id = _resolve_session("lamin track finish")
+            match = _run_uid_file(session_id) if session_id else None
+            if match is not None and match in candidates:
+                run_uid_file = match
+            else:
+                # last resort: most recently written state file
+                _common.warn(
+                    "multiple active Copilot sessions found in this directory and could not "
+                    "disambiguate which one is finishing — using the most recently started"
+                )
+                run_uid_file = max(candidates, key=lambda p: p.stat().st_mtime)
+
+        session_id = run_uid_file.name.removeprefix(".lamindb_run_uid_copilot_")
+        uid = run_uid_file.read_text().strip()
+        run = ln.Run.get(uid=uid)
+        transcript_path = _transcript_path(session_id)
+
+        if not transcript_path.exists():
+            _common.warn(
+                f"transcript file not found: {transcript_path} — closing run without report"
+            )
+            run._status_code = 0  # completed
+            run.finished_at = datetime.now(timezone.utc)
+            run.save()
+            run_uid_file.unlink()
+            return
+
+        entries = _parse_transcript(transcript_path)
+        html_doc = _common.render_transcript_html(
+            entries,
+            is_bookkeeping_bash_cmd=_is_bookkeeping_bash_cmd,
+            skill_marker=_SKILL_MARKER,
+            shell_tool_names=_SHELL_TOOL_NAMES,
+        )
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False)
+        tmp_path = Path(tmp.name)
+        try:
+            tmp.write(html_doc)
+            tmp.close()
+            artifact = ln.Artifact(
+                tmp.name,
+                description="Copilot session transcript (rendered)",
+                run=False,
+            ).save()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        run.report = artifact
+        _common.stamp_transforms(
+            run,
+            entries,
+            ln,
+            script_tool_names=_SCRIPT_TOOL_NAMES,
+            script_path_keys=_SCRIPT_PATH_KEYS,
+            suffix_to_kind=_SUFFIX_TO_KIND,
+        )
+
+        run._status_code = 0  # completed
+        run.finished_at = datetime.now(timezone.utc)
+        run.save()
+
+        run_uid_file.unlink()
+        _common.info(f"finished tracking Copilot session: {run.uid}")
+    except Exception as e:
+        _common.warn(f"lamindb session finish failed, continuing: {e}")
+        _common.warn(traceback.format_exc())

--- a/lamin_cli/agents/copilot.py
+++ b/lamin_cli/agents/copilot.py
@@ -153,7 +153,7 @@ def track_copilot_session(name: str | None = None) -> None:
             _common.warn("no lamindb instance connected, skipping session tracking")
             return
 
-        session_id = _resolve_session("lamin track copilot")
+        session_id = _resolve_session("track copilot")
         if session_id is None:
             _common.warn("could not resolve the active Copilot session, skipping session tracking")
             return
@@ -270,7 +270,7 @@ def finish_copilot_session() -> None:
         if len(candidates) == 1:
             run_uid_file = candidates[0]
         else:
-            session_id = _resolve_session("lamin track finish")
+            session_id = _resolve_session("track finish")
             match = _run_uid_file(session_id) if session_id else None
             if match is not None and match in candidates:
                 run_uid_file = match

--- a/lamin_cli/agents/copilot.py
+++ b/lamin_cli/agents/copilot.py
@@ -10,7 +10,7 @@ from lamin_cli.agents import _common
 
 # --- constants ---
 
-_STATE_DIR = Path(".claude")
+_STATE_DIR = Path(".copilot")
 _TRANSFORM_KEY = "__copilot__"
 _TRANSFORM_UID = "vl12ppCqQp2P0000"
 _SKILL_MARKER = "Base directory for this skill:"

--- a/lamin_cli/agents/copilot.py
+++ b/lamin_cli/agents/copilot.py
@@ -185,7 +185,7 @@ def track_copilot_session(name: str | None = None) -> None:
 
 
 def _is_bookkeeping_bash_cmd(cmd: str) -> bool:
-    return "lamin track copilot" in cmd or "lamin track finish" in cmd
+    return False
 
 
 def _parse_transcript(transcript_path: Path) -> list[dict]:

--- a/lamin_cli/agents/copilot.py
+++ b/lamin_cli/agents/copilot.py
@@ -313,6 +313,7 @@ def finish_copilot_session() -> None:
             artifact = ln.Artifact(
                 tmp.name,
                 description="Copilot session transcript (rendered)",
+                kind="__lamindb_run__",
                 run=False,
             ).save()
         finally:

--- a/lamin_cli/agents/copilot.py
+++ b/lamin_cli/agents/copilot.py
@@ -10,7 +10,6 @@ from lamin_cli.agents import _common
 
 # --- constants ---
 
-_STATE_DIR = Path(".copilot")
 _TRANSFORM_KEY = "__copilot__"
 _TRANSFORM_UID = "vl12ppCqQp2P0000"
 _SKILL_MARKER = "Base directory for this skill:"
@@ -130,8 +129,12 @@ def _resolve_session(match_text: str) -> str | None:
     return _resolve_session_via_self_invocation(match_text) or _resolve_session_via_workspace_scan()
 
 
+def _state_dir() -> Path:
+    return _common.resolve_state_dir(".copilot")
+
+
 def _run_uid_file(session_id: str) -> Path:
-    return _STATE_DIR / f".lamindb_run_uid_copilot_{session_id}"
+    return _state_dir() / f".lamindb_run_uid_copilot_{session_id}"
 
 
 def _transcript_path(session_id: str) -> Path:
@@ -171,7 +174,7 @@ def track_copilot_session(name: str | None = None) -> None:
 
         run = ln.Run(transform, status="started", name=name).save()
 
-        _STATE_DIR.mkdir(exist_ok=True)
+        _state_dir().mkdir(parents=True, exist_ok=True)
         _run_uid_file(session_id).write_text(run.uid)
         _common.info(f"started tracking Copilot session: {run.uid}")
     except Exception as e:
@@ -262,7 +265,7 @@ def finish_copilot_session() -> None:
             _common.warn("no lamindb instance connected, skipping session finish")
             return
 
-        candidates = sorted(_STATE_DIR.glob(".lamindb_run_uid_copilot_*"))
+        candidates = sorted(_state_dir().glob(".lamindb_run_uid_copilot_*"))
         if not candidates:
             _common.warn("no active Copilot session found, skipping session finish")
             return

--- a/tests/agents/test_track_copilot.py
+++ b/tests/agents/test_track_copilot.py
@@ -1,0 +1,194 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import lamindb as ln
+import pytest
+from lamin_cli.agents import copilot as copilot_agent
+from lamin_cli.agents.copilot import (
+    _STATE_DIR,
+    _TRANSFORM_KEY,
+    _run_uid_file,
+    finish_copilot_session,
+    track_copilot_session,
+)
+
+
+def _write_fake_session(state_dir: Path, session_id: str, cwd: str, command_texts: list[str]) -> None:
+    session_dir = state_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    (session_dir / "workspace.yaml").write_text(
+        f"id: {session_id}\ncwd: {cwd}\nclient_name: vscode\nname: test\ncreated_at: {now}\nupdated_at: {now}\n"
+    )
+    lines = [
+        json.dumps({"type": "session.start", "data": {"sessionId": session_id, "context": {"cwd": cwd}}, "id": "e0", "timestamp": now, "parentId": None})
+    ]
+    for i, cmd in enumerate(command_texts):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "tool.execution_start",
+                    "data": {"toolCallId": f"call{i}", "toolName": "bash", "arguments": {"command": cmd}},
+                    "id": f"e{i + 1}",
+                    "timestamp": now,
+                    "parentId": "e0",
+                }
+            )
+        )
+    (session_dir / "events.jsonl").write_text("\n".join(lines) + "\n")
+
+
+def _append_event(state_dir: Path, session_id: str, command_text: str) -> None:
+    """Add another tool.execution_start to an existing fake session, e.g. for finish."""
+    session_dir = state_dir / session_id
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    with (session_dir / "events.jsonl").open("a") as f:
+        f.write(
+            json.dumps(
+                {
+                    "type": "tool.execution_start",
+                    "data": {"toolCallId": "call-finish", "toolName": "bash", "arguments": {"command": command_text}},
+                    "id": "e-finish",
+                    "timestamp": now,
+                    "parentId": "e0",
+                }
+            )
+            + "\n"
+        )
+
+
+def _write_full_transcript(state_dir: Path, session_id: str) -> None:
+    """Give a session a realistic user/assistant exchange for report rendering."""
+    session_dir = state_dir / session_id
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    events = [
+        {"type": "user.message", "data": {"content": "do something"}, "id": "u1", "timestamp": now, "parentId": None},
+        {"type": "assistant.message", "data": {"content": "done", "toolRequests": []}, "id": "a1", "timestamp": now, "parentId": "u1"},
+    ]
+    with (session_dir / "events.jsonl").open("a") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    copilot_home = tmp_path / "copilot_home"
+    state_dir = copilot_home / "session-state"
+    state_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(copilot_agent, "_copilot_session_state_dir", lambda: state_dir)
+
+    yield state_dir, project_dir
+
+    t = ln.Transform.filter(key=_TRANSFORM_KEY).first()
+    if t is not None:
+        for run in t.runs.all():
+            report = run.report
+            if report is not None:
+                run.report = None
+                run.save()
+            run.delete(permanent=True)
+            if report is not None:
+                report.delete(permanent=True)
+        t.delete(permanent=True)
+
+
+def test_full_track_finish_flow(isolated):
+    state_dir, project_dir = isolated
+    cwd = str(project_dir)
+
+    _write_fake_session(state_dir, "session-a", cwd, ["lamin track copilot --name integration-test"])
+    track_copilot_session(name="integration test")
+
+    uid_file = _run_uid_file("session-a")
+    assert uid_file.exists()
+    uid = uid_file.read_text().strip()
+    session_run = ln.Run.get(uid=uid)
+    assert session_run.finished_at is None
+
+    # simulate a self-tracking script run with LAMIN_INITIATED_BY_RUN_UID set
+    child_transform = ln.Transform(key="analysis.py", kind="script").save()
+    child_run = ln.Run(child_transform, initiated_by_run=session_run)
+    child_run.finished_at = datetime.now(timezone.utc)
+    child_run.save()
+
+    _write_full_transcript(state_dir, "session-a")
+    _append_event(state_dir, "session-a", "lamin track finish")
+    finish_copilot_session()
+
+    assert not uid_file.exists()
+    session_run = ln.Run.get(uid=uid)
+    assert session_run.finished_at is not None
+    assert session_run.report is not None
+
+    child_transform = ln.Transform.get(key="analysis.py")
+    assert child_transform.run is not None
+    assert child_transform.run.uid == uid
+
+    child_run.delete(permanent=True)
+    child_transform.delete(permanent=True)
+
+
+def test_multiple_sessions_use_separate_state_files(isolated):
+    state_dir, project_dir = isolated
+    cwd = str(project_dir)
+
+    _write_fake_session(state_dir, "session-a", cwd, ["lamin track copilot --name a"])
+    track_copilot_session(name="session a")
+    uid_a = _run_uid_file("session-a").read_text().strip()
+
+    _write_fake_session(state_dir, "session-b", cwd, ["lamin track copilot --name b"])
+    track_copilot_session(name="session b")
+    uid_b = _run_uid_file("session-b").read_text().strip()
+
+    assert uid_a != uid_b
+    assert _run_uid_file("session-a").exists()
+    assert _run_uid_file("session-b").exists()
+
+
+def test_track_reuses_transform_across_sessions(isolated):
+    state_dir, project_dir = isolated
+    cwd = str(project_dir)
+
+    _write_fake_session(state_dir, "session-a", cwd, ["lamin track copilot --name a"])
+    track_copilot_session(name="session a")
+
+    _write_fake_session(state_dir, "session-b", cwd, ["lamin track copilot --name b"])
+    track_copilot_session(name="session b")
+
+    assert ln.Transform.filter(key=_TRANSFORM_KEY).count() == 1
+
+
+def test_finish_disambiguates_via_self_invocation_when_multiple_sessions_active(isolated):
+    state_dir, project_dir = isolated
+    cwd = str(project_dir)
+
+    _write_fake_session(state_dir, "session-a", cwd, ["lamin track copilot --name a"])
+    track_copilot_session(name="session a")
+    uid_a = _run_uid_file("session-a").read_text().strip()
+
+    _write_fake_session(state_dir, "session-b", cwd, ["lamin track copilot --name b"])
+    track_copilot_session(name="session b")
+    uid_b = _run_uid_file("session-b").read_text().strip()
+
+    # both sessions are now tracked in the same directory; only session-b
+    # logs a "lamin track finish" — session-a must be left untouched.
+    _write_full_transcript(state_dir, "session-b")
+    _append_event(state_dir, "session-b", "lamin track finish")
+    finish_copilot_session()
+
+    assert not _run_uid_file("session-b").exists()
+    assert _run_uid_file("session-a").exists()  # untouched
+    assert ln.Run.get(uid=uid_b).finished_at is not None
+    assert ln.Run.get(uid=uid_a).finished_at is None
+
+    # cleanup session-a's still-open run
+    ln.Run.get(uid=uid_a).delete(permanent=True)
+
+
+def test_finish_without_active_session_exits_cleanly(isolated):
+    finish_copilot_session()

--- a/tests/agents/test_track_copilot.py
+++ b/tests/agents/test_track_copilot.py
@@ -1,5 +1,6 @@
+import itertools
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import lamindb as ln
@@ -13,11 +14,26 @@ from lamin_cli.agents.copilot import (
     track_copilot_session,
 )
 
+# Real Copilot events have millisecond timestamps, which is what
+# `_resolve_session_via_self_invocation` relies on to break ties between
+# sessions whose logged commands both match the same generic search text.
+# A plain `datetime.now()` truncated to whole seconds (as opposed to real
+# sub-second precision) can make two fixture-written events land on the
+# identical string, which makes resolution order depend on filesystem
+# iteration order instead of recency. Use a monotonically increasing fake
+# clock instead so ordering between fixture calls is always deterministic.
+_fake_clock = itertools.count()
+
+
+def _next_timestamp() -> str:
+    dt = datetime.now(timezone.utc) + timedelta(milliseconds=10 * next(_fake_clock))
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
 
 def _write_fake_session(state_dir: Path, session_id: str, cwd: str, command_texts: list[str]) -> None:
     session_dir = state_dir / session_id
     session_dir.mkdir(parents=True, exist_ok=True)
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    now = _next_timestamp()
     (session_dir / "workspace.yaml").write_text(
         f"id: {session_id}\ncwd: {cwd}\nclient_name: vscode\nname: test\ncreated_at: {now}\nupdated_at: {now}\n"
     )
@@ -31,7 +47,7 @@ def _write_fake_session(state_dir: Path, session_id: str, cwd: str, command_text
                     "type": "tool.execution_start",
                     "data": {"toolCallId": f"call{i}", "toolName": "bash", "arguments": {"command": cmd}},
                     "id": f"e{i + 1}",
-                    "timestamp": now,
+                    "timestamp": _next_timestamp(),
                     "parentId": "e0",
                 }
             )
@@ -42,7 +58,7 @@ def _write_fake_session(state_dir: Path, session_id: str, cwd: str, command_text
 def _append_event(state_dir: Path, session_id: str, command_text: str) -> None:
     """Add another tool.execution_start to an existing fake session, e.g. for finish."""
     session_dir = state_dir / session_id
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    now = _next_timestamp()
     with (session_dir / "events.jsonl").open("a") as f:
         f.write(
             json.dumps(
@@ -61,7 +77,7 @@ def _append_event(state_dir: Path, session_id: str, command_text: str) -> None:
 def _write_full_transcript(state_dir: Path, session_id: str) -> None:
     """Give a session a realistic user/assistant exchange for report rendering."""
     session_dir = state_dir / session_id
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    now = _next_timestamp()
     events = [
         {"type": "user.message", "data": {"content": "do something"}, "id": "u1", "timestamp": now, "parentId": None},
         {"type": "assistant.message", "data": {"content": "done", "toolRequests": []}, "id": "a1", "timestamp": now, "parentId": "u1"},

--- a/tests/agents/test_track_copilot.py
+++ b/tests/agents/test_track_copilot.py
@@ -7,7 +7,6 @@ import lamindb as ln
 import pytest
 from lamin_cli.agents import copilot as copilot_agent
 from lamin_cli.agents.copilot import (
-    _STATE_DIR,
     _TRANSFORM_KEY,
     _run_uid_file,
     finish_copilot_session,


### PR DESCRIPTION
- Adds lamin track copilot for tracking GitHub Copilot sessions, mirroring lamin track claude (same lamin track finish closes either)
- Extracted the agent-agnostic HTML rendering and transform-stamping logic into agents/_common.py, shared by both claude.py and the new copilot.py (Claude's own behavior is unchanged)
- Copilot sessions get their own __copilot__ Transform, separate from Claude's __claudecode__.

ISSUE: https://github.com/pfizer-collab/laminlabs/issues/1124